### PR TITLE
feat(server): 多提供商数组配置与启动初始化; fix(qwen-auth): 复用缓存凭据与账号级刷新清理 (src-only)

### DIFF
--- a/src/api-server.js
+++ b/src/api-server.js
@@ -80,7 +80,7 @@
  * --host <address>                    服务器监听地址 / Server listening address (default: localhost)
  * --port <number>                     服务器监听端口 / Server listening port (default: 3000)
  * --api-key <key>                     身份验证所需的 API 密钥 / Required API key for authentication (default: 123456)
- * --model-provider <provider>         AI 模型提供商 / AI model provider: openai-custom, claude-custom, gemini-cli-oauth, claude-kiro-oauth
+ * --model-provider <provider[,provider...]> AI 模型提供商 / AI model provider: openai-custom, claude-custom, gemini-cli-oauth, claude-kiro-oauth
  * --openai-api-key <key>             OpenAI API 密钥 / OpenAI API key (for openai-custom provider)
  * --openai-base-url <url>            OpenAI API 基础 URL / OpenAI API base URL (for openai-custom provider)
  * --claude-api-key <key>             Claude API 密钥 / Claude API key (for claude-custom provider)
@@ -126,6 +126,47 @@ import {
 
 let CONFIG = {}; // Make CONFIG exportable
 let PROMPT_LOG_FILENAME = ''; // Make PROMPT_LOG_FILENAME exportable
+
+const ALL_MODEL_PROVIDERS = Object.values(MODEL_PROVIDER);
+
+function normalizeConfiguredProviders(config) {
+    const fallbackProvider = MODEL_PROVIDER.GEMINI_CLI;
+    const dedupedProviders = [];
+
+    const addProvider = (value) => {
+        if (typeof value !== 'string') {
+            return;
+        }
+        const trimmed = value.trim();
+        if (!trimmed) {
+            return;
+        }
+        const matched = ALL_MODEL_PROVIDERS.find((provider) => provider.toLowerCase() === trimmed.toLowerCase());
+        if (!matched) {
+            console.warn(`[Config Warning] Unknown model provider '${trimmed}'. This entry will be ignored.`);
+            return;
+        }
+        if (!dedupedProviders.includes(matched)) {
+            dedupedProviders.push(matched);
+        }
+    };
+
+    const rawValue = config.MODEL_PROVIDER;
+    if (Array.isArray(rawValue)) {
+        rawValue.forEach((entry) => addProvider(typeof entry === 'string' ? entry : String(entry)));
+    } else if (typeof rawValue === 'string') {
+        rawValue.split(',').forEach(addProvider);
+    } else if (rawValue != null) {
+        addProvider(String(rawValue));
+    }
+
+    if (dedupedProviders.length === 0) {
+        dedupedProviders.push(fallbackProvider);
+    }
+
+    config.DEFAULT_MODEL_PROVIDERS = dedupedProviders;
+    config.MODEL_PROVIDER = dedupedProviders[0];
+}
 
 /**
  * Initializes the server configuration from config.json and command-line arguments.
@@ -335,6 +376,8 @@ async function initializeConfig(args = process.argv.slice(2), configFilePath = '
         }
     }
 
+    normalizeConfiguredProviders(currentConfig);
+
     if (!currentConfig.SYSTEM_PROMPT_FILE_PATH) {
         currentConfig.SYSTEM_PROMPT_FILE_PATH = INPUT_SYSTEM_PROMPT_FILE;
     }
@@ -412,21 +455,73 @@ async function initApiService(config) {
         console.log('[Initialization] No provider pools configured. Using single provider mode.');
     }
 
-    // Initialize all known service adapters at startup
-    // 当存在号池时，这里不再提前初始化所有 provider 的实例，而是按需从号池中选择和初始化
-    // 而是通过 providerPoolManager.selectProvider 来动态选择配置并初始化服务
-    for (const provider of Object.values(MODEL_PROVIDER)) {
-        if (!config.providerPools || !config.providerPools[provider] || config.providerPools[provider].length === 0) {
-            try {
-                // 对于没有配置号池的提供者，仍然按原来的方式初始化一个单例
-                console.log(`[Initialization] Initializing single service adapter for ${provider}...`);
-                getServiceAdapter({ ...config, MODEL_PROVIDER: provider }); // This call populates serviceInstances
-            } catch (error) {
-                console.warn(`[Initialization Warning] Failed to initialize single service adapter for ${provider}: ${error.message}`);
-            }
+    // Initialize configured service adapters at startup
+    // 对于未纳入号池的提供者，提前初始化以避免首个请求的额外延迟
+    const providersToInit = new Set();
+    if (Array.isArray(config.DEFAULT_MODEL_PROVIDERS)) {
+        config.DEFAULT_MODEL_PROVIDERS.forEach((provider) => providersToInit.add(provider));
+    }
+    if (config.providerPools) {
+        Object.keys(config.providerPools).forEach((provider) => providersToInit.add(provider));
+    }
+    if (providersToInit.size === 0) {
+        ALL_MODEL_PROVIDERS.forEach((provider) => providersToInit.add(provider));
+    }
+
+    for (const provider of providersToInit) {
+        if (!ALL_MODEL_PROVIDERS.includes(provider)) {
+            console.warn(`[Initialization Warning] Skipping unknown model provider '${provider}' during adapter initialization.`);
+            continue;
+        }
+        if (config.providerPools && config.providerPools[provider] && config.providerPools[provider].length > 0) {
+            // 由号池管理器负责按需初始化
+            continue;
+        }
+        try {
+            console.log(`[Initialization] Initializing single service adapter for ${provider}...`);
+            getServiceAdapter({ ...config, MODEL_PROVIDER: provider });
+        } catch (error) {
+            console.warn(`[Initialization Warning] Failed to initialize single service adapter for ${provider}: ${error.message}`);
         }
     }
     return serviceInstances; // Return the collection of initialized service instances
+}
+
+function logProviderSpecificDetails(provider, config) {
+    switch (provider) {
+        case MODEL_PROVIDER.OPENAI_CUSTOM:
+            console.log(`  [openai-custom] API Key: ${config.OPENAI_API_KEY ? '******' : 'Not Set'}`);
+            console.log(`  [openai-custom] Base URL: ${config.OPENAI_BASE_URL || 'Default'}`);
+            break;
+        case MODEL_PROVIDER.CLAUDE_CUSTOM:
+            console.log(`  [claude-custom] API Key: ${config.CLAUDE_API_KEY ? '******' : 'Not Set'}`);
+            console.log(`  [claude-custom] Base URL: ${config.CLAUDE_BASE_URL || 'Default'}`);
+            break;
+        case MODEL_PROVIDER.GEMINI_CLI:
+            if (config.GEMINI_OAUTH_CREDS_FILE_PATH) {
+                console.log(`  [gemini-cli-oauth] OAuth Creds File Path: ${config.GEMINI_OAUTH_CREDS_FILE_PATH}`);
+            } else if (config.GEMINI_OAUTH_CREDS_BASE64) {
+                console.log(`  [gemini-cli-oauth] OAuth Creds Source: Provided via Base64 string`);
+            } else {
+                console.log(`  [gemini-cli-oauth] OAuth Creds: Default discovery`);
+            }
+            console.log(`  [gemini-cli-oauth] Project ID: ${config.PROJECT_ID || 'Auto-discovered'}`);
+            break;
+        case MODEL_PROVIDER.KIRO_API:
+            if (config.KIRO_OAUTH_CREDS_FILE_PATH) {
+                console.log(`  [claude-kiro-oauth] OAuth Creds File Path: ${config.KIRO_OAUTH_CREDS_FILE_PATH}`);
+            } else if (config.KIRO_OAUTH_CREDS_BASE64) {
+                console.log(`  [claude-kiro-oauth] OAuth Creds Source: Provided via Base64 string`);
+            } else {
+                console.log(`  [claude-kiro-oauth] OAuth Creds: Default`);
+            }
+            break;
+        case MODEL_PROVIDER.QWEN_API:
+            console.log(`  [openai-qwen-oauth] OAuth Creds File Path: ${config.QWEN_OAUTH_CREDS_FILE_PATH || 'Default'}`);
+            break;
+        default:
+            console.log(`  [${provider}] Provider initialized.`);
+    }
 }
 
 async function getApiService(config) {
@@ -606,21 +701,15 @@ async function startServer() {
     const server = http.createServer(requestHandlerInstance);
     server.listen(CONFIG.SERVER_PORT, CONFIG.HOST, () => {
         console.log(`--- Unified API Server Configuration ---`);
-        console.log(`  Model Provider: ${CONFIG.MODEL_PROVIDER}`);
-        if (CONFIG.MODEL_PROVIDER === MODEL_PROVIDER.OPENAI_CUSTOM) {
-            console.log(`  OpenAI API Key: ${CONFIG.OPENAI_API_KEY ? '******' : 'Not Set'}`);
-            console.log(`  OpenAI Base URL: ${CONFIG.OPENAI_BASE_URL}`);
-        } else if (CONFIG.MODEL_PROVIDER === MODEL_PROVIDER.CLAUDE_CUSTOM) {
-            console.log(`  Claude API Key: ${CONFIG.CLAUDE_API_KEY ? '******' : 'Not Set'}`);
-            console.log(`  Claude Base URL: ${CONFIG.CLAUDE_BASE_URL}`);
-        } else if (CONFIG.MODEL_PROVIDER === MODEL_PROVIDER.GEMINI_CLI) {
-            console.log(`  Gemini OAuth Creds File Path: ${CONFIG.GEMINI_OAUTH_CREDS_FILE_PATH || 'Default'}`);
-            console.log(`  Project ID: ${CONFIG.PROJECT_ID || 'Auto-discovered'}`);
-        } else if (CONFIG.MODEL_PROVIDER === MODEL_PROVIDER.KIRO_API) {
-           console.log(`  Kiro OAuth Creds File Path: ${CONFIG.KIRO_OAUTH_CREDS_FILE_PATH || 'Default'}`);
-       } else if (CONFIG.MODEL_PROVIDER === MODEL_PROVIDER.QWEN_API) {
-           console.log(`  Qwen OAuth Creds File Path: ${CONFIG.QWEN_OAUTH_CREDS_FILE_PATH || 'Default'}`);
-       }
+        const configuredProviders = Array.isArray(CONFIG.DEFAULT_MODEL_PROVIDERS) && CONFIG.DEFAULT_MODEL_PROVIDERS.length > 0
+            ? CONFIG.DEFAULT_MODEL_PROVIDERS
+            : [CONFIG.MODEL_PROVIDER];
+        const uniqueProviders = [...new Set(configuredProviders)];
+        console.log(`  Primary Model Provider: ${CONFIG.MODEL_PROVIDER}`);
+        if (uniqueProviders.length > 1) {
+            console.log(`  Additional Model Providers: ${uniqueProviders.slice(1).join(', ')}`);
+        }
+        uniqueProviders.forEach((provider) => logProviderSpecificDetails(provider, CONFIG));
         console.log(`  System Prompt File: ${CONFIG.SYSTEM_PROMPT_FILE_PATH || 'Default'}`);
         console.log(`  System Prompt Mode: ${CONFIG.SYSTEM_PROMPT_MODE}`);
         console.log(`  Host: ${CONFIG.HOST}`);


### PR DESCRIPTION


概述

  - 修复 Qwen OAuth 在号池多账号场景下的两处关键问题（缓存凭据不生效、刷新清理路径错配），显著降低频繁设备
  授权与刷新失败。
  - 增强多提供商同时启用的配置与启动体验（数组/逗号分隔配置、启动期预初始化与更清晰的日志）。
  - 提交仅包含 src/* 目录变更，便于审阅与合入。

  历史问题与现象

  - 频繁设备授权：即使本地已保存有效凭据，服务仍反复触发设备授权，影响稳定性。
  - 刷新失败持续：refresh_token 失效（HTTP 400）后仍然不断失败、难以自愈，号池中的 Qwen 账号易被标记为不
  健康。
  - 多账号轮询存在但不稳定：ProviderPoolManager 可轮询到多个 Qwen 代理，但由于上面两个问题，Qwen 账号经常
  失败。

  根因分析（对照历史代码）

  - 缓存可用性判断恒为失败
      - 旧版 _loadCachedQwenCredentials 设置完凭据后调用了不存在的 client.getAccessToken()，异常被吞、结果
  恒为 false，后续总进入设备授权流。
      - 参考旧实现: fe42aed 的 src/openai/qwen-core.js:297, 302-304（逻辑分布，调用 getAccessToken 的位置）
  - 刷新失败时清理了“错误路径”
      - 旧版在 HTTP 400 时删除固定路径 ~/.qwen/oauth_creds.json，与号池中“每个账号自定义的凭据路径”不一致，
  导致对应账号坏凭据未被清理，持续失败。
      - 参考旧实现: fe42aed 的 src/openai/qwen-core.js:663
  - 管理器未按账号路径隔离
      - 旧版 SharedTokenManager 内部用默认路径方法（如 getCredentialFilePath），与服务层基于账号路径写入的
  缓存错位，导致“服务读写 A 文件，管理器刷新 B 文件”。

  本次修复（核心改动）

  - 按账号路径做缓存/刷新/清理（路径对齐、账号隔离）
      - 服务层显式传入账号的凭据路径，管理器基于该路径维护独立的缓存/锁/读写。
      - src/openai/qwen-core.js:11（构造时注入 tokenManagerOptions），31–37（getValidCredentials(...,
  this.tokenManagerOptions)），552–606（getContext/resolveCredentialFilePath/resolveLockFilePath）
  - 缓存凭据正确复用（避免无谓设备授权）
      - 使用 access_token 存在且 expiry_date 未临近过期判断缓存可用；可用则直接返回，不再跑设备授权。
      - src/openai/qwen-core.js:59–66（可用即返回）、322–333（移除 getAccessToken 调用，改为 access_token +
  expiry_date 判定）
  - 刷新 400 时按账号路径清理（避免误删）
      - 刷新 400 不再直接删除默认路径文件，而是抛 status=400；共享管理器捕获后删除“当前上下文账号”的凭据文
  件 context.credentialFilePath。
      - src/openai/qwen-core.js:796（抛出 err.status=400）、721（按 context.credentialFilePath 删除）

  多提供商并行（配置/启动增强）

  - 支持 MODEL_PROVIDER 为数组或逗号分隔字符串，启动期标准化为 DEFAULT_MODEL_PROVIDERS，首个为默认；按
  DEFAULT_MODEL_PROVIDERS + 号池键集合 预初始化，日志展示“Primary + Additional Providers”。
  - src/api-server.js:132（normalizeConfiguredProviders）、177（启动期标准化）、455（预初始化集合）、
  701（启动日志展示）