### PR TITLE
feat(kiro): 增强凭证验证并添加缺失参数告警日志

### DIFF
--- a/src/claude/claude-kiro.js
+++ b/src/claude/claude-kiro.js
@@ -473,6 +473,13 @@ async initializeAuth(forceRefresh = false) {
                 requestBody.clientId = this.clientId;
                 requestBody.clientSecret = this.clientSecret;
                 requestBody.grantType = 'refresh_token';
+                if (!this.clientId) {
+                    console.warn('[Kiro Auth] clientId not found in credentials.')
+                }
+                if (!this.clientSecret) {
+                    console.warn('[Kiro Auth] clientSecret not found in credentials.')
+                }
+
             }
             const response = await this.axiosInstance.post(refreshUrl, requestBody);
             console.log('[Kiro Auth] Token refresh response: ok');


### PR DESCRIPTION
在 BuilderId 登录方式下（authMethod=IdC），系统会使用 clientId 和 clientSecret 刷新凭证。 kiro-auth-token.json原始文件中不包含 clientId 和 clientSecret 属性，导致凭证刷新失败。用户需要从 ~/.aws/sso/cache 目录下的其他 JSON 文件中复制这两个属性到 kiro-auth-token.json 文件中。