### PR TITLE
feat(usage): 添加provider健康检查接口

### DIFF
--- a/src/request-handler.js
+++ b/src/request-handler.js
@@ -2,7 +2,7 @@ import deepmerge from 'deepmerge';
 import { handleError, isAuthorized } from './common.js';
 import { handleUIApiRequests, serveStaticFiles } from './ui-manager.js';
 import { handleAPIRequests } from './api-manager.js';
-import { getApiService } from './service-manager.js';
+import { getApiService, getProviderStatus } from './service-manager.js';
 import { getProviderPoolManager } from './service-manager.js';
 import { MODEL_PROVIDER } from './common.js';
 import { PROMPT_LOG_FILENAME } from './config-manager.js';
@@ -60,6 +60,38 @@ export function createRequestHandler(config, providerPoolManager) {
                 provider: currentConfig.MODEL_PROVIDER
             }));
             return true;
+        }
+
+        // providers health endpoint
+        // url params: provider[string], customName[string], unhealthRatioThreshold[float]
+        // 支持provider, customName过滤记录 
+        // 支持unhealthRatioThreshold控制不健康比例的阈值, 当unhealthyRatio超过阈值返回summaryHealthy: false
+        if (method === 'GET' && path === '/provider_health') {
+            try {
+                const provider = requestUrl.searchParams.get('provider');
+                const customName = requestUrl.searchParams.get('customName');
+                const unhealthRatioThreshold = parseFloat(requestUrl.searchParams.get('unhealthRatioThreshold'));
+                let provideStatus = await getProviderStatus(currentConfig, null, { provider, customName });
+                let summaryHealthy = true;
+                if (!isNaN(unhealthRatioThreshold)) {
+                    summaryHealthy = provideStatus.unhealthyRatio <= unhealthRatioThreshold;
+                }
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({
+                    timestamp: new Date().toISOString(),
+                    items: provideStatus.providerPoolsSlim,
+                    count: provideStatus.count,
+                    unhealthyCount: provideStatus.unhealthyCount,
+                    unhealthyRatio: provideStatus.unhealthyRatio,
+                    unhealthySummeryMessage: provideStatus.unhealthySummeryMessage,
+                    summaryHealthy
+                }));
+                return true;
+            } catch (error) {
+                console.log(`[Server] req provider_health error: ${error.message}`);
+                handleError(res, { statusCode: 500, message: `Failed to get providers health: ${error.message}` });
+                return;
+            }
         }
 
         // Ignore count_tokens requests


### PR DESCRIPTION
## 概要
添加独立的provider健康检查接口（与web UI管理中provider信息接口不同），用于系统provider检测

## 应用场景
通过获取provider状态，结合相关监控、告警系统整合

## 使用案例
结合[Uptime Kuma](https://github.com/louislam/uptime-kuma)，实现provider异常告警通知

```bash
# 获取所有已启用的provider记录状态
curl  http:/host:port/provider_health

# 支持provider, customName过滤记录
curl  http:/host:port/provider_health?provider=gemini-antigravity&customName=hello

# 支持unhealthRatioThreshold控制不健康比例的阈值, 当unhealthyRatio超过阈值返回summaryHealthy: false
curl  http:/host:port/provider_health?unhealthRatioThreshold=0.3
````

## 响应样例
```json
{
	"timestamp": "2025-12-21T16:22:51.390Z",
	"items": [
		{
			"customName": null,
			"isHealthy": true,
			"lastErrorTime": null,
			"lastErrorMessage": null,
			"identify": "NoCustomName::claude-kiro-oauth::./configs/kiro/1766327484403_kiro-auth-token/1766327484403_kiro-auth-token.json",
			"provider": "claude-kiro-oauth"
		},
		{
			"customName": null,
			"isHealthy": true,
			"lastErrorTime": null,
			"lastErrorMessage": null,
			"identify": "NoCustomName::gemini-antigravity::./configs/antigravity/1766327471161_antigravity-credential-1766054214572.json",
			"provider": "gemini-antigravity"
		},
		{
			"customName": null,
			"isHealthy": true,
			"lastErrorTime": null,
			"lastErrorMessage": null,
			"identify": "NoCustomName::gemini-antigravity::./configs/antigravity/1766329435057_antigravity-credential-1766054214572.json",
			"provider": "gemini-antigravity"
		}
	],
	"count": 3,
	"unhealthyCount": 0,
	"unhealthyRatio": 0,
	"unhealthySummeryMessage": null,
	"summaryHealthy": true
}
```

## 原理
数据源基于providerPoolManager和PROVIDER_POOLS_FILE_PATH