### PR TITLE
add project payload in fetchAvailableModels request to get correct remainingFraction

### DIFF
--- a/src/gemini/antigravity-core.js
+++ b/src/gemini/antigravity-core.js
@@ -808,7 +808,7 @@ export class AntigravityApiService {
                             'User-Agent': this.userAgent
                         },
                         responseType: 'json',
-                        body: JSON.stringify({})
+                        body: JSON.stringify({ project: this.projectId })
                     };
 
                     const res = await this.authClient.request(requestOptions);


### PR DESCRIPTION
在我使用中，我发现antigravity的用量查询结果总是不对，于是做了一些调试。结果发现是fetchAvailableModels请求中缺少project信息。添加后就可以正常显示antigravity的用量了。