### PR TITLE
feat(converters): add display_name field to model list responses

### DIFF
--- a/src/converters/strategies/ClaudeConverter.js
+++ b/src/converters/strategies/ClaudeConverter.js
@@ -607,12 +607,16 @@ export class ClaudeConverter extends BaseConverter {
     toOpenAIModelList(claudeModels) {
         return {
             object: "list",
-            data: claudeModels.models.map(m => ({
-                id: m.id || m.name,
-                object: "model",
-                created: Math.floor(Date.now() / 1000),
-                owned_by: "anthropic",
-            })),
+            data: claudeModels.models.map(m => {
+                const modelId = m.id || m.name;
+                return {
+                    id: modelId,
+                    object: "model",
+                    created: Math.floor(Date.now() / 1000),
+                    owned_by: "anthropic",
+                    display_name: modelId,
+                };
+            }),
         };
     }
 

--- a/src/converters/strategies/GeminiConverter.js
+++ b/src/converters/strategies/GeminiConverter.js
@@ -289,12 +289,16 @@ export class GeminiConverter extends BaseConverter {
     toOpenAIModelList(geminiModels) {
         return {
             object: "list",
-            data: geminiModels.models.map(m => ({
-                id: m.name.startsWith('models/') ? m.name.substring(7) : m.name,
-                object: "model",
-                created: Math.floor(Date.now() / 1000),
-                owned_by: "google",
-            })),
+            data: geminiModels.models.map(m => {
+                const modelId = m.name.startsWith('models/') ? m.name.substring(7) : m.name;
+                return {
+                    id: modelId,
+                    object: "model",
+                    created: Math.floor(Date.now() / 1000),
+                    owned_by: "google",
+                    display_name: m.displayName || modelId,
+                };
+            }),
         };
     }
 

--- a/src/converters/strategies/OpenAIConverter.js
+++ b/src/converters/strategies/OpenAIConverter.js
@@ -103,8 +103,25 @@ export class OpenAIConverter extends BaseConverter {
             case MODEL_PROTOCOL_PREFIX.GEMINI:
                 return this.toGeminiModelList(data);
             default:
-                return data;
+                return this.ensureDisplayName(data);
         }
+    }
+
+    /**
+     * Ensure display_name field exists in OpenAI model list
+     */
+    ensureDisplayName(openaiModels) {
+        if (!openaiModels || !openaiModels.data) {
+            return openaiModels;
+        }
+
+        return {
+            ...openaiModels,
+            data: openaiModels.data.map(model => ({
+                ...model,
+                display_name: model.display_name || model.id,
+            })),
+        };
     }
 
     // =========================================================================


### PR DESCRIPTION
Add display_name field to model list conversions across all converter strategies to improve model identification in API responses. ClaudeConverter and GeminiConverter now include display_name in their toOpenAIModelList methods, while OpenAIConverter adds ensureDisplayName method to guarantee the field exists for native OpenAI models.

It fix this error:
<img width="540" height="406" alt="image" src="https://github.com/user-attachments/assets/76ff7888-2304-47e3-8f54-dcd963a88df6" />
