### PR TITLE
feat(kiro): 添加认证错误自动标记不健康及凭证切换重试机制，解决401 和403的问题

### DIFF
--- a/src/providers/claude/claude-kiro.js
+++ b/src/providers/claude/claude-kiro.js
@@ -9,7 +9,8 @@ import * as https from 'https';
 import { getProviderModels } from '../provider-models.js';
 import { countTokens } from '@anthropic-ai/tokenizer';
 import { configureAxiosProxy } from '../../utils/proxy-utils.js';
-import { isRetryableNetworkError } from '../../utils/common.js';
+import { isRetryableNetworkError, MODEL_PROVIDER } from '../../utils/common.js';
+import { getProviderPoolManager } from '../../services/service-manager.js';
 
 const KIRO_THINKING = {
     MAX_BUDGET_TOKENS: 24576,
@@ -1212,15 +1213,26 @@ async initializeAuth(forceRefresh = false) {
             // 检查是否为可重试的网络错误
             const isNetworkError = isRetryableNetworkError(error);
             
-            if (status === 403 && !isRetry) {
-                console.log('[Kiro] Received 403. Attempting token refresh and retrying...');
+            // Handle 401 (Unauthorized) - try to refresh token first
+            if (status === 401 && !isRetry) {
+                console.log('[Kiro] Received 401. Attempting token refresh...');
                 try {
                     await this.initializeAuth(true); // Force refresh token
+                    console.log('[Kiro] Token refresh successful after 401, retrying request...');
                     return this.callApi(method, model, body, true, retryCount);
                 } catch (refreshError) {
-                    console.error('[Kiro] Token refresh failed during 403 retry:', refreshError.message);
+                    console.error('[Kiro] Token refresh failed during 401 retry:', refreshError.message);
+                    // Mark credential as unhealthy immediately and attach marker to error
+                    this._markCredentialUnhealthy('401 Unauthorized - Token refresh failed', refreshError);
                     throw refreshError;
                 }
+            }
+    
+            // Handle 403 (Forbidden) - mark as unhealthy immediately, no retry
+            if (status === 403) {
+                console.log('[Kiro] Received 403. Marking credential as unhealthy...');
+                this._markCredentialUnhealthy('403 Forbidden', error);
+                throw error;
             }
             
             // Handle 429 (Too Many Requests) with exponential backoff
@@ -1250,6 +1262,31 @@ async initializeAuth(forceRefresh = false) {
 
             console.error(`[Kiro] API call failed (Status: ${status}, Code: ${errorCode}):`, error.message);
             throw error;
+        }
+    }
+
+    /**
+     * Helper method to mark the current credential as unhealthy
+     * @param {string} reason - The reason for marking unhealthy
+     * @param {Error} [error] - Optional error object to attach the marker to
+     * @returns {boolean} - Whether the credential was successfully marked as unhealthy
+     * @private
+     */
+    _markCredentialUnhealthy(reason, error = null) {
+        const poolManager = getProviderPoolManager();
+        if (poolManager && this.uuid) {
+            console.log(`[Kiro] Marking credential ${this.uuid} as unhealthy. Reason: ${reason}`);
+            poolManager.markProviderUnhealthyImmediately(MODEL_PROVIDER.KIRO_API, {
+                uuid: this.uuid
+            }, reason);
+            // Attach marker to error object to prevent duplicate marking in upper layers
+            if (error) {
+                error.credentialMarkedUnhealthy = true;
+            }
+            return true;
+        } else {
+            console.warn(`[Kiro] Cannot mark credential as unhealthy: poolManager=${!!poolManager}, uuid=${this.uuid}`);
+            return false;
         }
     }
 
@@ -1537,11 +1574,27 @@ async initializeAuth(forceRefresh = false) {
             // 检查是否为可重试的网络错误
             const isNetworkError = isRetryableNetworkError(error);
             
-            if (status === 403 && !isRetry) {
-                console.log('[Kiro] Received 403 in stream. Attempting token refresh and retrying...');
-                await this.initializeAuth(true);
-                yield* this.streamApiReal(method, model, body, true, retryCount);
-                return;
+            // Handle 401 (Unauthorized) - try to refresh token first
+            if (status === 401 && !isRetry) {
+                console.log('[Kiro] Received 401 in stream. Attempting token refresh...');
+                try {
+                    await this.initializeAuth(true); // Force refresh token
+                    console.log('[Kiro] Token refresh successful after 401, retrying stream...');
+                    yield* this.streamApiReal(method, model, body, true, retryCount);
+                    return;
+                } catch (refreshError) {
+                    console.error('[Kiro] Token refresh failed during 401 retry:', refreshError.message);
+                    // Mark credential as unhealthy immediately and attach marker to error
+                    this._markCredentialUnhealthy('401 Unauthorized - Token refresh failed', refreshError);
+                    throw refreshError;
+                }
+            }
+            
+            // Handle 403 (Forbidden) - mark as unhealthy immediately, no retry
+            if (status === 403) {
+                console.log('[Kiro] Received 403 in stream. Marking credential as unhealthy...');
+                this._markCredentialUnhealthy('403 Forbidden', error);
+                throw error;
             }
             
             if (status === 429 && retryCount < maxRetries) {
@@ -2355,24 +2408,42 @@ async initializeAuth(forceRefresh = false) {
             console.log('[Kiro] Usage limits fetched successfully');
             return response.data;
         } catch (error) {
-            // 如果是 403 错误，尝试刷新 token 后重试
-            if (error.response?.status === 403) {
-                console.log('[Kiro] Received 403 on getUsageLimits. Attempting token refresh and retrying...');
-                try {
-                    await this.initializeAuth(true);
-                    // 更新 Authorization header
-                    headers['Authorization'] = `Bearer ${this.accessToken}`;
-                    headers['amz-sdk-invocation-id'] = uuidv4();
-                    const retryResponse = await this.axiosInstance.get(fullUrl, { headers });
-                    console.log('[Kiro] Usage limits fetched successfully after token refresh');
-                    return retryResponse.data;
-                } catch (refreshError) {
-                    console.error('[Kiro] Token refresh failed during getUsageLimits retry:', refreshError.message);
-                    throw refreshError;
+            const status = error.response?.status;
+            
+            // 从响应体中提取错误信息
+            let errorMessage = error.message;
+            if (error.response?.data) {
+                // 尝试从响应体中获取错误描述
+                const responseData = error.response.data;
+                if (typeof responseData === 'string') {
+                    errorMessage = responseData;
+                } else if (responseData.message) {
+                    errorMessage = responseData.message;
+                } else if (responseData.error) {
+                    errorMessage = typeof responseData.error === 'string' ? responseData.error : responseData.error.message || JSON.stringify(responseData.error);
                 }
             }
-            console.error('[Kiro] Failed to fetch usage limits:', error.message, error);
-            throw error;
+            
+            // 构建包含状态码和错误描述的错误信息
+            const formattedError = status
+                ? new Error(`API call failed: ${status} - ${errorMessage}`)
+                : new Error(`API call failed: ${errorMessage}`);
+            
+            // 对于用量查询，401/403 错误直接标记凭证为不健康，不重试
+            if (status === 401) {
+                console.log('[Kiro] Received 401 on getUsageLimits. Marking credential as unhealthy (no retry)...');
+                this._markCredentialUnhealthy('401 Unauthorized on usage query', formattedError);
+                throw formattedError;
+            }
+            
+            if (status === 403) {
+                console.log('[Kiro] Received 403 on getUsageLimits. Marking credential as unhealthy (no retry)...');
+                this._markCredentialUnhealthy('403 Forbidden on usage query', formattedError);
+                throw formattedError;
+            }
+            
+            console.error('[Kiro] Failed to fetch usage limits:', formattedError.message, error);
+            throw formattedError;
         }
     }
 }

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -217,13 +217,22 @@ export async function handleUnifiedResponse(res, responsePayload, isStream) {
     }
 }
 
-export async function handleStreamRequest(res, service, model, requestBody, fromProvider, toProvider, PROMPT_LOG_MODE, PROMPT_LOG_FILENAME, providerPoolManager, pooluuid, customName) {
+export async function handleStreamRequest(res, service, model, requestBody, fromProvider, toProvider, PROMPT_LOG_MODE, PROMPT_LOG_FILENAME, providerPoolManager, pooluuid, customName, retryContext = null) {
     let fullResponseText = '';
     let fullResponseJson = '';
     let fullOldResponseJson = '';
     let responseClosed = false;
+    
+    // 重试上下文：包含 CONFIG 和重试计数
+    const maxRetries = retryContext?.maxRetries ?? 2;
+    const currentRetry = retryContext?.currentRetry ?? 0;
+    const CONFIG = retryContext?.CONFIG;
+    const isRetry = currentRetry > 0;
 
-    await handleUnifiedResponse(res, '', true);
+    // 只在首次请求时发送响应头，重试时跳过（响应头已发送）
+    if (!isRetry) {
+        await handleUnifiedResponse(res, '', true);
+    }
 
     // fs.writeFile('request'+Date.now()+'.json', JSON.stringify(requestBody));
     // The service returns a stream in its native format (toProvider).
@@ -283,12 +292,80 @@ export async function handleStreamRequest(res, service, model, requestBody, from
 
     }  catch (error) {
         console.error('\n[Server] Error during stream processing:', error.stack);
-        if (providerPoolManager && pooluuid) {
-            console.log(`[Provider Pool] Marking ${toProvider} as unhealthy due to stream error`);
+        
+        // 如果已经发送了内容，不进行重试（避免响应数据损坏）
+        if (fullResponseText.length > 0) {
+            console.log(`[Stream Retry] Cannot retry: ${fullResponseText.length} bytes already sent to client`);
+            // 直接发送错误并结束
+            const errorPayload = createStreamErrorResponse(error, fromProvider);
+            res.write(errorPayload);
+            res.end();
+            responseClosed = true;
+            return;
+        }
+        
+        // 获取状态码（用于日志记录，不再用于判断是否重试）
+        const status = error.response?.status;
+        
+        // 检查凭证是否已在底层被标记为不健康（避免重复标记）
+        let credentialMarkedUnhealthy = error.credentialMarkedUnhealthy === true;
+        
+        // 如果底层未标记，则在此处标记
+        if (!credentialMarkedUnhealthy && providerPoolManager && pooluuid) {
+            console.log(`[Provider Pool] Marking ${toProvider} as unhealthy due to stream error (status: ${status || 'unknown'})`);
             // 如果是号池模式，并且请求处理失败，则标记当前使用的提供者为不健康
             providerPoolManager.markProviderUnhealthy(toProvider, {
                 uuid: pooluuid
             });
+            credentialMarkedUnhealthy = true;
+        } else if (credentialMarkedUnhealthy) {
+            console.log(`[Provider Pool] Credential ${pooluuid} already marked as unhealthy by lower layer, skipping duplicate marking`);
+        }
+        
+        // 凭证已被标记为不健康后，尝试切换到新凭证重试
+        // 不再依赖状态码判断，只要凭证被标记不健康且可以重试，就尝试切换
+        if (credentialMarkedUnhealthy && currentRetry < maxRetries && providerPoolManager && CONFIG) {
+            console.log(`[Stream Retry] Credential marked unhealthy. Attempting retry ${currentRetry + 1}/${maxRetries} with different credential...`);
+            
+            try {
+                // 动态导入以避免循环依赖
+                const { getApiServiceWithFallback } = await import('../services/service-manager.js');
+                const result = await getApiServiceWithFallback(CONFIG, model);
+                
+                if (result && result.service && result.uuid !== pooluuid) {
+                    console.log(`[Stream Retry] Switched to new credential: ${result.uuid} (provider: ${result.actualProviderType})`);
+                    
+                    // 使用新服务重试
+                    const newRetryContext = {
+                        ...retryContext,
+                        CONFIG,
+                        currentRetry: currentRetry + 1,
+                        maxRetries
+                    };
+                    
+                    // 递归调用，使用新的服务
+                    return await handleStreamRequest(
+                        res,
+                        result.service,
+                        result.actualModel || model,
+                        requestBody,
+                        fromProvider,
+                        result.actualProviderType || toProvider,
+                        PROMPT_LOG_MODE,
+                        PROMPT_LOG_FILENAME,
+                        providerPoolManager,
+                        result.uuid,
+                        result.serviceConfig?.customName || customName,
+                        newRetryContext
+                    );
+                } else if (result && result.uuid === pooluuid) {
+                    console.log(`[Stream Retry] No different healthy credential available. Same credential selected.`);
+                } else {
+                    console.log(`[Stream Retry] No healthy credential available for retry.`);
+                }
+            } catch (retryError) {
+                console.error(`[Stream Retry] Failed to get alternative service:`, retryError.message);
+            }
         }
 
         // 使用新方法创建符合 fromProvider 格式的流式错误响应
@@ -307,7 +384,12 @@ export async function handleStreamRequest(res, service, model, requestBody, from
 }
 
 
-export async function handleUnaryRequest(res, service, model, requestBody, fromProvider, toProvider, PROMPT_LOG_MODE, PROMPT_LOG_FILENAME, providerPoolManager, pooluuid, customName) {
+export async function handleUnaryRequest(res, service, model, requestBody, fromProvider, toProvider, PROMPT_LOG_MODE, PROMPT_LOG_FILENAME, providerPoolManager, pooluuid, customName, retryContext = null) {
+    // 重试上下文：包含 CONFIG 和重试计数
+    const maxRetries = retryContext?.maxRetries ?? 2;
+    const currentRetry = retryContext?.currentRetry ?? 0;
+    const CONFIG = retryContext?.CONFIG;
+    
     try{
         // The service returns the response in its native format (toProvider).
         const needsConversion = getProtocolPrefix(fromProvider) !== getProtocolPrefix(toProvider);
@@ -338,12 +420,69 @@ export async function handleUnaryRequest(res, service, model, requestBody, fromP
         }
     } catch (error) {
         console.error('\n[Server] Error during unary processing:', error.stack);
-        if (providerPoolManager && pooluuid) {
-            console.log(`[Provider Pool] Marking ${toProvider} as unhealthy due to stream error`);
+        
+        // 获取状态码（用于日志记录，不再用于判断是否重试）
+        const status = error.response?.status;
+        
+        // 检查凭证是否已在底层被标记为不健康（避免重复标记）
+        let credentialMarkedUnhealthy = error.credentialMarkedUnhealthy === true;
+        
+        // 如果底层未标记，则在此处标记
+        if (!credentialMarkedUnhealthy && providerPoolManager && pooluuid) {
+            console.log(`[Provider Pool] Marking ${toProvider} as unhealthy due to unary error (status: ${status || 'unknown'})`);
             // 如果是号池模式，并且请求处理失败，则标记当前使用的提供者为不健康
             providerPoolManager.markProviderUnhealthy(toProvider, {
                 uuid: pooluuid
             });
+            credentialMarkedUnhealthy = true;
+        } else if (credentialMarkedUnhealthy) {
+            console.log(`[Provider Pool] Credential ${pooluuid} already marked as unhealthy by lower layer, skipping duplicate marking`);
+        }
+        
+        // 凭证已被标记为不健康后，尝试切换到新凭证重试
+        // 不再依赖状态码判断，只要凭证被标记不健康且可以重试，就尝试切换
+        if (credentialMarkedUnhealthy && currentRetry < maxRetries && providerPoolManager && CONFIG) {
+            console.log(`[Unary Retry] Credential marked unhealthy. Attempting retry ${currentRetry + 1}/${maxRetries} with different credential...`);
+            
+            try {
+                // 动态导入以避免循环依赖
+                const { getApiServiceWithFallback } = await import('../services/service-manager.js');
+                const result = await getApiServiceWithFallback(CONFIG, model);
+                
+                if (result && result.service && result.uuid !== pooluuid) {
+                    console.log(`[Unary Retry] Switched to new credential: ${result.uuid} (provider: ${result.actualProviderType})`);
+                    
+                    // 使用新服务重试
+                    const newRetryContext = {
+                        ...retryContext,
+                        CONFIG,
+                        currentRetry: currentRetry + 1,
+                        maxRetries
+                    };
+                    
+                    // 递归调用，使用新的服务
+                    return await handleUnaryRequest(
+                        res,
+                        result.service,
+                        result.actualModel || model,
+                        requestBody,
+                        fromProvider,
+                        result.actualProviderType || toProvider,
+                        PROMPT_LOG_MODE,
+                        PROMPT_LOG_FILENAME,
+                        providerPoolManager,
+                        result.uuid,
+                        result.serviceConfig?.customName || customName,
+                        newRetryContext
+                    );
+                } else if (result && result.uuid === pooluuid) {
+                    console.log(`[Unary Retry] No different healthy credential available. Same credential selected.`);
+                } else {
+                    console.log(`[Unary Retry] No healthy credential available for retry.`);
+                }
+            } catch (retryError) {
+                console.error(`[Unary Retry] Failed to get alternative service:`, retryError.message);
+            }
         }
 
         // 使用新方法创建符合 fromProvider 格式的错误响应
@@ -487,10 +626,13 @@ export async function handleContentGenerationRequest(req, res, service, endpoint
     await logConversation('input', promptText, CONFIG.PROMPT_LOG_MODE, PROMPT_LOG_FILENAME);
     
     // 5. Call the appropriate stream or unary handler, passing the provider info.
+    // 创建重试上下文，包含 CONFIG 以便在认证错误时切换凭证重试
+    const retryContext = providerPoolManager ? { CONFIG, currentRetry: 0, maxRetries: 2 } : null;
+    
     if (isStream) {
-        await handleStreamRequest(res, service, model, processedRequestBody, fromProvider, toProvider, CONFIG.PROMPT_LOG_MODE, PROMPT_LOG_FILENAME, providerPoolManager, actualUuid, actualCustomName);
+        await handleStreamRequest(res, service, model, processedRequestBody, fromProvider, toProvider, CONFIG.PROMPT_LOG_MODE, PROMPT_LOG_FILENAME, providerPoolManager, actualUuid, actualCustomName, retryContext);
     } else {
-        await handleUnaryRequest(res, service, model, processedRequestBody, fromProvider, toProvider, CONFIG.PROMPT_LOG_MODE, PROMPT_LOG_FILENAME, providerPoolManager, actualUuid, actualCustomName);
+        await handleUnaryRequest(res, service, model, processedRequestBody, fromProvider, toProvider, CONFIG.PROMPT_LOG_MODE, PROMPT_LOG_FILENAME, providerPoolManager, actualUuid, actualCustomName, retryContext);
     }
 
     // 执行插件钩子：内容生成后


### PR DESCRIPTION
### 概述

本 PR 为 KIRO 模式添加了完善的认证错误（401/403）处理逻辑，并实现了凭证切换重试机制，提高了服务的可用性和稳定性。

### 变更内容

#### 1. KIRO 请求错误处理

- **401 Unauthorized**：尝试刷新 token 后重试，如果刷新失败则标记凭证为不健康
- **403 Forbidden**：直接标记凭证为不健康，不进行重试
- 适用于 `callApi()` 和 `streamApiReal()` 方法

#### 2. 用量查询错误处理

- **401/403 错误**：直接标记凭证为不健康，返回详细错误信息（不重试）
- 适用于 `getUsageLimits()` 方法

#### 3. 凭证切换重试机制

- 当凭证被标记为不健康后，自动尝试切换到其他健康凭证进行重试
- 最大重试次数：2 次
- 流式请求：如果已发送数据则不重试，避免响应数据损坏

#### 4. 新增 Pool Manager 方法

- `markProviderUnhealthyImmediately()`：立即标记凭证为不健康（用于认证错误）
- 与 `markProviderUnhealthy()` 的区别：不累计错误计数，直接标记

#### 5. UI 健康检查改进

- 对认证错误（401/403）使用 `markProviderUnhealthyImmediately()` 立即标记

### 变更文件

| 文件 | 变更 |
|------|------|
| `src/providers/claude/claude-kiro.js` | +121 行 |
| `src/providers/provider-pool-manager.js` | +29 行 |
| `src/ui-modules/provider-api.js` | +32 行 |
| `src/utils/common.js` | +162 行 |

### 对其他 Provider 的影响

| Provider | 影响 | 说明 |
|----------|------|------|
| **Gemini CLI OAuth** | ❌ 无影响 | 原有逻辑保持不变 |
| **Gemini Antigravity** | ❌ 无影响 | 原有逻辑保持不变 |
| **Claude Orchids** | ❌ 无影响 | 原有逻辑保持不变 |
| **OpenAI** | ❌ 无影响 | 原有逻辑保持不变 |
| **Qwen** | ❌ 无影响 | 原有逻辑保持不变 |
| **iFlow** | ❌ 无影响 | 原有逻辑保持不变 |

#### 详细说明

1. **KIRO 特定代码**：`claude-kiro.js` 的变更仅影响 KIRO 模式
2. **Pool Manager 新方法**：`markProviderUnhealthyImmediately()` 是新增方法，不影响现有调用
3. **common.js 变更**：
   - 添加了 `retryContext` 参数（可选，默认 null）
   - 添加了 `credentialMarkedUnhealthy` 检查
   - 其他 Provider 不设置此标记，因此会走原有的 `markProviderUnhealthy()` 逻辑（累计错误计数）
4. **UI 健康检查**：对所有 Provider 的认证错误立即标记不健康（正向改进）

### 新增功能（对所有 Provider）

- 请求失败时会尝试切换凭证重试（如果号池中有多个健康凭证）
- 这是一个**可选的正向改进**，不会破坏现有功能

### 测试建议

1. 测试 KIRO 模式的 401/403 错误处理
2. 测试凭证切换重试机制
3. 验证其他 Provider（Gemini、OpenAI 等）的正常功能不受影响