### PR TITLE
feat(config): 添加坏凭证切换最大重试次数配置项，支持自定义配置，默认5。

### DIFF
--- a/src/core/config-manager.js
+++ b/src/core/config-manager.js
@@ -75,6 +75,7 @@ export async function initializeConfig(args = process.argv.slice(2), configFileP
             PROMPT_LOG_MODE: "none",
             REQUEST_MAX_RETRIES: 3,
             REQUEST_BASE_DELAY: 1000,
+            CREDENTIAL_SWITCH_MAX_RETRIES: 5, // 坏凭证切换最大重试次数（用于认证错误后切换凭证）
             CRON_NEAR_MINUTES: 15,
             CRON_REFRESH_TOKEN: false,
             PROVIDER_POOLS_FILE_PATH: null, // 新增号池配置文件路径

--- a/src/ui-modules/config-api.js
+++ b/src/ui-modules/config-api.js
@@ -83,6 +83,7 @@ export async function handleUpdateConfig(req, res, currentConfig) {
         if (newConfig.PROMPT_LOG_MODE !== undefined) currentConfig.PROMPT_LOG_MODE = newConfig.PROMPT_LOG_MODE;
         if (newConfig.REQUEST_MAX_RETRIES !== undefined) currentConfig.REQUEST_MAX_RETRIES = newConfig.REQUEST_MAX_RETRIES;
         if (newConfig.REQUEST_BASE_DELAY !== undefined) currentConfig.REQUEST_BASE_DELAY = newConfig.REQUEST_BASE_DELAY;
+        if (newConfig.CREDENTIAL_SWITCH_MAX_RETRIES !== undefined) currentConfig.CREDENTIAL_SWITCH_MAX_RETRIES = newConfig.CREDENTIAL_SWITCH_MAX_RETRIES;
         if (newConfig.CRON_NEAR_MINUTES !== undefined) currentConfig.CRON_NEAR_MINUTES = newConfig.CRON_NEAR_MINUTES;
         if (newConfig.CRON_REFRESH_TOKEN !== undefined) currentConfig.CRON_REFRESH_TOKEN = newConfig.CRON_REFRESH_TOKEN;
         if (newConfig.PROVIDER_POOLS_FILE_PATH !== undefined) currentConfig.PROVIDER_POOLS_FILE_PATH = newConfig.PROVIDER_POOLS_FILE_PATH;
@@ -131,6 +132,7 @@ export async function handleUpdateConfig(req, res, currentConfig) {
                 PROMPT_LOG_MODE: currentConfig.PROMPT_LOG_MODE,
                 REQUEST_MAX_RETRIES: currentConfig.REQUEST_MAX_RETRIES,
                 REQUEST_BASE_DELAY: currentConfig.REQUEST_BASE_DELAY,
+                CREDENTIAL_SWITCH_MAX_RETRIES: currentConfig.CREDENTIAL_SWITCH_MAX_RETRIES,
                 CRON_NEAR_MINUTES: currentConfig.CRON_NEAR_MINUTES,
                 CRON_REFRESH_TOKEN: currentConfig.CRON_REFRESH_TOKEN,
                 PROVIDER_POOLS_FILE_PATH: currentConfig.PROVIDER_POOLS_FILE_PATH,

--- a/static/app/config-manager.js
+++ b/static/app/config-manager.js
@@ -90,6 +90,11 @@ async function loadConfiguration() {
         if (promptLogModeEl) promptLogModeEl.value = data.PROMPT_LOG_MODE || 'none';
         if (requestMaxRetriesEl) requestMaxRetriesEl.value = data.REQUEST_MAX_RETRIES || 3;
         if (requestBaseDelayEl) requestBaseDelayEl.value = data.REQUEST_BASE_DELAY || 1000;
+        
+        // 坏凭证切换最大重试次数
+        const credentialSwitchMaxRetriesEl = document.getElementById('credentialSwitchMaxRetries');
+        if (credentialSwitchMaxRetriesEl) credentialSwitchMaxRetriesEl.value = data.CREDENTIAL_SWITCH_MAX_RETRIES || 5;
+        
         if (cronNearMinutesEl) cronNearMinutesEl.value = data.CRON_NEAR_MINUTES || 1;
         if (cronRefreshTokenEl) cronRefreshTokenEl.checked = data.CRON_REFRESH_TOKEN || false;
         if (providerPoolsFilePathEl) providerPoolsFilePathEl.value = data.PROVIDER_POOLS_FILE_PATH;
@@ -187,6 +192,7 @@ async function saveConfiguration() {
     config.PROMPT_LOG_MODE = document.getElementById('promptLogMode')?.value || '';
     config.REQUEST_MAX_RETRIES = parseInt(document.getElementById('requestMaxRetries')?.value || 3);
     config.REQUEST_BASE_DELAY = parseInt(document.getElementById('requestBaseDelay')?.value || 1000);
+    config.CREDENTIAL_SWITCH_MAX_RETRIES = parseInt(document.getElementById('credentialSwitchMaxRetries')?.value || 5);
     config.CRON_NEAR_MINUTES = parseInt(document.getElementById('cronNearMinutes')?.value || 1);
     config.CRON_REFRESH_TOKEN = document.getElementById('cronRefreshToken')?.checked || false;
     config.PROVIDER_POOLS_FILE_PATH = document.getElementById('providerPoolsFilePath')?.value || '';

--- a/static/components/section-config.html
+++ b/static/components/section-config.html
@@ -164,6 +164,14 @@
                 
                 <div class="config-row">
                     <div class="form-group">
+                        <label for="credentialSwitchMaxRetries" data-i18n="config.advanced.credentialSwitchMaxRetries">坏凭证切换最大重试次数</label>
+                        <input type="number" id="credentialSwitchMaxRetries" class="form-control" min="1" max="50" value="5">
+                        <small class="form-text" data-i18n="config.advanced.credentialSwitchMaxRetriesNote">认证错误(401/403)后切换凭证的最大重试次数，默认 5 次</small>
+                    </div>
+                </div>
+                
+                <div class="config-row">
+                    <div class="form-group">
                         <label for="cronNearMinutes" data-i18n="config.advanced.cronInterval">OAuth令牌刷新间隔(分钟)</label>
                         <input type="number" id="cronNearMinutes" class="form-control" min="1" max="60" value="1">
                     </div>


### PR DESCRIPTION
### 📋 概述

新增 `CREDENTIAL_SWITCH_MAX_RETRIES` 配置项，允许用户自定义凭证切换的最大重试次数，提升系统在多凭证场景下的容错能力。

### 🎯 动机与背景

当使用 Provider Pool（号池）功能时，系统会在遇到认证错误（401/403）后自动切换到其他健康凭证进行重试。此前重试次数硬编码为 2 次，对于拥有大量凭证的用户来说可能不够灵活。本次更新将该值改为可配置，默认值提升至 5 次。

### ✨ 变更内容

| 文件 | 变更说明 |
|------|----------|
| `src/core/config-manager.js` | 添加 `CREDENTIAL_SWITCH_MAX_RETRIES` 配置初始化，默认值为 5 |
| `src/ui-modules/config-api.js` | 支持配置项的读取和更新 |
| `src/utils/common.js` | 使用配置值控制凭证切换重试次数 |
| `static/app/config-manager.js` | 前端配置加载和保存逻辑 |
| `static/components/section-config.html` | 添加配置输入控件 |

### 🔧 技术细节

**配置初始化：**
```javascript
CREDENTIAL_SWITCH_MAX_RETRIES: 5, // 坏凭证切换最大重试次数（用于认证错误后切换凭证）
```

**使用方式：**
```javascript
// 凭证切换重试次数（默认 5），可在配置中自定义更大的值
// 注意：这与底层的 429/5xx 重试（REQUEST_MAX_RETRIES）是不同层次的重试机制
// - 底层重试：同一凭证遇到 429/5xx 时的重试
// - 凭证切换重试：凭证被标记不健康后切换到其他凭证
// 当没有不同的健康凭证可用时，重试会自动停止
const credentialSwitchMaxRetries = CONFIG.CREDENTIAL_SWITCH_MAX_RETRIES || 5;
```

### 📝 重试机制说明

本系统存在两层重试机制：

| 重试类型 | 配置项 | 触发条件 | 说明 |
|----------|--------|----------|------|
| 底层重试 | `REQUEST_MAX_RETRIES` | 429/5xx 错误 | 同一凭证内的重试 |
| 凭证切换重试 | `CREDENTIAL_SWITCH_MAX_RETRIES` | 401/403 错误 | 切换到其他健康凭证 |
