### PR TITLE
修復gemini-cli用量查詢

### DIFF
--- a/src/providers/gemini/gemini-core.js
+++ b/src/providers/gemini/gemini-core.js
@@ -690,7 +690,7 @@ export class GeminiApiService {
             try {
                 const quotaURL = `${this.codeAssistEndpoint}/${this.apiVersion}:retrieveUserQuota`;
                 const requestBody = {
-                    project: `projects/${this.projectId}`
+                    project: `${this.projectId}`
                 };
                 const requestOptions = {
                     url: quotaURL,


### PR DESCRIPTION
如題 現在使用網頁控制台時，client向gemini-cli api (https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota)
發送以下參數:

{
  "project": "projects/{project ID}"
}

經過跟官方gemini-cli 的請求比對之後發現AIClient-2-API這個projects參數多出'projects/'
結果網頁控制台查詢永遠看不到gemini3的模型，以及查詢得出的quota數永遠都不對。
用proxyman攔截請求，把'projects/' 刪去再發一次，就可以看到伺服器返回正確的模型列表跟quota

問題出在gemini-core.js 693行, 經過驗證，把'projects/' 刪除之後就能獲取正確quota。