### PR TITLE
refactor(claude-orchids): 重构提示词模板并添加模型映射机制

### DIFF
--- a/src/providers/provider-models.js
+++ b/src/providers/provider-models.js
@@ -37,7 +37,6 @@ export const PROVIDER_MODELS = {
         'claude-sonnet-4-5',
         'claude-opus-4-5',
         'claude-haiku-4-5',
-        'gemini-3',
         'gemini-3-flash',
         'gpt-5.2'
     ],


### PR DESCRIPTION
1. 重写系统提示词模板，采用更清晰的XML结构
2. 移除冗余的规则声明，简化提示词内容
3. 添加模型名称映射逻辑，将不支持的模型转换为支持的模型
4. 新增 claude-opus-4-5 的支持。