### PR TITLE
fix: add global config

### DIFF
--- a/src/providers/provider-pool-manager.js
+++ b/src/providers/provider-pool-manager.js
@@ -379,6 +379,7 @@ export class ProviderPoolManager {
 
             // 使用适配器进行刷新
             const tempConfig = {
+                ...this.globalConfig,
                 ...config,
                 MODEL_PROVIDER: providerType
             };


### PR DESCRIPTION
<img width="2304" height="1350" alt="904d2af52e687a9a0e4d7438416efd29" src="https://github.com/user-attachments/assets/14f3cd57-c2c4-4e47-9d24-e746e2d105e7" />

当前 config 对象仅有 provider 的相关配置，缺少全局 config，导致相关 Service（GeminiApiService） 初始化时，无法读取相关配置，比如：PROXY_URL，进而对相关配置失效。

The current config object only contains provider-specific settings and is missing the global configuration. This prevents Service( GeminiApiService ) from accessing global variables like PROXY_URL during initialization, causing those settings to fail.