### PR TITLE
fix: 修复插件管理页面卡片重复渲染问题

### DIFF
--- a/static/app/plugin-manager.js
+++ b/static/app/plugin-manager.js
@@ -63,6 +63,8 @@ function renderPluginsList() {
     const emptyEl = document.getElementById('pluginsEmpty');
     
     if (!listEl) return;
+
+    listEl.innerHTML = '';
     
     if (pluginsList.length === 0) {
         if (emptyEl) emptyEl.style.display = 'flex';


### PR DESCRIPTION
## 问题描述

插件管理页面（Plugins）中，插件卡片会重复显示。例如 ai-monitor、api-potluck、default-auth 等插件各出现两次。

## 根因分析

`static/app/plugin-manager.js` 中的 `renderPluginsList()` 函数在渲染插件卡片时，只通过 `appendChild` 向容器追加元素，但**没有先清空容器**。

虽然 `loadPlugins()` 在调用 `renderPluginsList()` 之前会执行 `listEl.innerHTML = ""`，但在以下场景中仍会导致重复：

- 快速连续调用（初始化 + 组件加载完成事件触发）
- `togglePlugin` 切换状态后重新加载列表

## 修复方案

在 `renderPluginsList()` 函数开头添加 `listEl.innerHTML = ""` 清空容器，确保每次渲染都是干净的，从根本上防止卡片重复。

## 改动范围

- `static/app/plugin-manager.js`：`renderPluginsList()` 函数增加一行清空逻辑

改动极小（+1 行），无副作用。