### PR TITLE
fix: 修复同会话跨模型缓存键不命中问题

### DIFF
--- a/src/providers/openai/codex-core.js
+++ b/src/providers/openai/codex-core.js
@@ -310,13 +310,11 @@ export class CodexApiService {
         delete cleanedBody.metadata;
 
         // 生成会话缓存键
-        // 默认弱化 model 依赖，以提升同会话跨模型的缓存命中率
-        // 如果 sessionId 为 'default'，则必须加上 model 以提供基础隔离
+        // 弱化 model 依赖，以提升同会话跨模型的缓存命中率
+        // 仅当 sessionId 为 'default' 时加上 model 前缀，提供基础隔离
         let cacheKey = sessionId;
         if (sessionId === 'default') {
             cacheKey = `${model}-default`;
-        } else {
-            cacheKey = `${model}-${sessionId}`;
         }
         
         let cache = this.conversationCache.get(cacheKey);


### PR DESCRIPTION
## 问题描述

修复 #328 中报告的 Claude Code → Codex 会话缓存隔离与跨模型缓存命中问题。

## 根因分析

`codex-core.js` 的 `prepareRequestBody()` 中，缓存键生成逻辑存在矛盾：

- **注释说**："弱化 model 依赖，以提升同会话跨模型的缓存命中率"
- **实际代码**：非 default 情况下仍然拼接了 model 前缀 `${model}-${sessionId}`

这导致同一会话内切换模型（如 gpt-5-codex-mini → gpt-5-codex）时，缓存键不同，无法命中缓存。

## 修复方案

移除非 default sessionId 时的 model 前缀拼接：

```javascript
// 修复前
if (sessionId === 'default') {
    cacheKey = \`${model}-default\`;
} else {
    cacheKey = \`${model}-${sessionId}\`;  // ❌ 违背弱化 model 依赖的设计意图
}

// 修复后
if (sessionId === 'default') {
    cacheKey = \`${model}-default\`;
}
// else: cacheKey 保持为 sessionId，不拼接 model
```

## 效果

- ✅ 同会话跨模型缓存命中（sessionId 相同即可复用）
- ✅ 不同会话稳定隔离（不同 sessionId 天然隔离）
- ✅ 无 sessionId 时（default）仍按 model 隔离，保持基础安全性
- ✅ metadata 不透传上游（已在 prepareRequestBody 中正确删除）

## 关联 Issue 评论

@ylqgithubylq 在 #328 评论中也指出了 else 分支不应该拼接 model 的问题。