### PR TITLE
fix: 修复 Codex→Claude 流式转换并发串流导致 content_block_start 丢失的问题

### DIFF
--- a/src/convert/convert.js
+++ b/src/convert/convert.js
@@ -39,7 +39,7 @@ import {
  * @returns {object} 转换后的数据
  * @throws {Error} 如果找不到合适的转换函数
  */
-export function convertData(data, type, fromProvider, toProvider, model) {
+export function convertData(data, type, fromProvider, toProvider, model, requestId) {
     try {
         // 获取协议前缀
         const fromProtocol = getProtocolPrefix(fromProvider);
@@ -67,7 +67,7 @@ export function convertData(data, type, fromProvider, toProvider, model) {
                 return converter.convertResponse(data, toProtocol, model);
                 
             case 'streamChunk':
-                return converter.convertStreamChunk(data, toProtocol, model);
+                return converter.convertStreamChunk(data, toProtocol, model, requestId);
                 
             case 'modelList':
                 return converter.convertModelList(data, toProtocol);

--- a/src/converters/strategies/CodexConverter.js
+++ b/src/converters/strategies/CodexConverter.js
@@ -55,7 +55,7 @@ export class CodexConverter extends BaseConverter {
     /**
      * 转换流式响应块
      */
-    convertStreamChunk(chunk, targetProtocol, model) {
+    convertStreamChunk(chunk, targetProtocol, model, requestId) {
         switch (targetProtocol) {
             case MODEL_PROTOCOL_PREFIX.OPENAI:
                 return this.toOpenAIStreamChunk(chunk, model);
@@ -64,7 +64,7 @@ export class CodexConverter extends BaseConverter {
             case MODEL_PROTOCOL_PREFIX.GEMINI:
                 return this.toGeminiStreamChunk(chunk, model);
             case MODEL_PROTOCOL_PREFIX.CLAUDE:
-                return this.toClaudeStreamChunk(chunk, model);
+                return this.toClaudeStreamChunk(chunk, model, requestId);
             case MODEL_PROTOCOL_PREFIX.CODEX:
                 return chunk; // Codex to Codex
             default:
@@ -1124,67 +1124,26 @@ export class CodexConverter extends BaseConverter {
     /**
      * Codex → Claude 流式响应转换
      */
-    toClaudeStreamChunk(chunk, model) {
+    toClaudeStreamChunk(chunk, model, requestId) {
         const type = chunk.type;
 
-        // 初始化 item_id → resId 映射表（用于并发流隔离）
-        if (!this._claudeItemToResId) {
-            this._claudeItemToResId = new Map();
-        }
+        // 使用 requestId 作为流状态的隔离 key（并发安全）。
+        // 每个请求在 handleStreamRequest 中生成唯一 requestId，
+        // 确保同一单例 converter 上的并发流状态完全独立。
+        const stateKey = requestId || chunk.response?.id || 'default';
 
-        // Codex 的多数增量事件不带 response.id，需要通过 item_id 映射或兜底逻辑归并到正确的流状态。
-        let resId = chunk.response?.id;
-        if (!resId) {
-            // 优先通过 item_id 精确匹配到对应的 response（并发安全）
-            const itemId = chunk.item_id || chunk.item?.id;
-            if (itemId && this._claudeItemToResId.has(itemId)) {
-                resId = this._claudeItemToResId.get(itemId);
-            } else if (this.lastClaudeStreamResponseId && this.streamParams.has(this.lastClaudeStreamResponseId)) {
-                resId = this.lastClaudeStreamResponseId;
-            } else if (this.streamParams.size === 1) {
-                resId = this.streamParams.keys().next().value;
-            } else {
-                // 兜底：选择最近更新的流，避免落到固定 "default" key 导致串流状态污染。
-                let latestKey = null;
-                let latestUpdatedAt = -1;
-                for (const [key, streamState] of this.streamParams.entries()) {
-                    const updatedAt = streamState?.lastUpdatedAt || 0;
-                    if (updatedAt > latestUpdatedAt) {
-                        latestUpdatedAt = updatedAt;
-                        latestKey = key;
-                    }
-                }
-                resId = latestKey || 'default';
-            }
-        }
-
-        if (!this.streamParams.has(resId)) {
-            this.streamParams.set(resId, {
+        // response.created 携带 response.id，用它来初始化该请求的流状态
+        if (type === 'response.created') {
+            const resId = chunk.response.id;
+            this.streamParams.set(stateKey, {
                 model: model,
                 createdAt: Math.floor(Date.now() / 1000),
                 responseID: resId,
                 blockIndex: 0,
-                blockStarted: false, // track whether content_block_start has been sent for current block
-                currentBlockType: null, // 'thinking' or 'text'
-                lastUpdatedAt: Date.now()
+                blockStarted: false,
+                currentBlockType: null,
             });
-        }
-        const state = this.streamParams.get(resId);
-        state.lastUpdatedAt = Date.now();
-
-        // 捕获 response.output_item.added 事件中的 item_id → resId 映射，
-        // 使后续 delta 事件能通过 item_id 精确关联到正确的流（并发安全）。
-        if (type === 'response.output_item.added') {
-            const itemId = chunk.item?.id;
-            if (itemId && resId) {
-                this._claudeItemToResId.set(itemId, resId);
-            }
-            return null; // 此事件不产生 Claude 输出
-        }
-
-        if (type === 'response.created') {
-            state.responseID = chunk.response.id;
-            this.lastClaudeStreamResponseId = state.responseID;
+            const state = this.streamParams.get(stateKey);
             return {
                 type: "message_start",
                 message: {
@@ -1196,6 +1155,30 @@ export class CodexConverter extends BaseConverter {
                     usage: { input_tokens: 0, output_tokens: 0 }
                 }
             };
+        }
+
+        if (!this.streamParams.has(stateKey)) {
+            // 如果还没有状态（比如没有收到 response.created 就收到了其他事件），
+            // 用 chunk 中能拿到的信息初始化
+            this.streamParams.set(stateKey, {
+                model: model,
+                createdAt: Math.floor(Date.now() / 1000),
+                responseID: chunk.response?.id || stateKey,
+                blockIndex: 0,
+                blockStarted: false,
+                currentBlockType: null,
+            });
+        }
+        const state = this.streamParams.get(stateKey);
+
+        // response.output_item.added 不产生 Claude 输出
+        if (type === 'response.output_item.added') {
+            return null;
+        }
+
+        if (type === 'response.created') {
+            // 已在上方处理，不应到达此处
+            return null;
         }
 
         if (type === 'response.reasoning_summary_text.delta') {
@@ -1304,18 +1287,8 @@ export class CodexConverter extends BaseConverter {
                 },
                 { type: "message_stop" }
             );
-            // 清理 item_id → resId 映射，避免内存泄漏
-            if (this._claudeItemToResId) {
-                for (const [itemId, mappedResId] of this._claudeItemToResId.entries()) {
-                    if (mappedResId === resId) {
-                        this._claudeItemToResId.delete(itemId);
-                    }
-                }
-            }
-            this.streamParams.delete(resId);
-            if (this.lastClaudeStreamResponseId === resId) {
-                this.lastClaudeStreamResponseId = null;
-            }
+            // 清理该请求的流状态
+            this.streamParams.delete(stateKey);
             return events;
         }
 

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -344,6 +344,8 @@ export async function handleStreamRequest(res, service, model, requestBody, from
         requestBody.model = model;
         const nativeStream = await service.generateContentStream(model, requestBody);
         const addEvent = getProtocolPrefix(fromProvider) === MODEL_PROTOCOL_PREFIX.CLAUDE || getProtocolPrefix(fromProvider) === MODEL_PROTOCOL_PREFIX.OPENAI_RESPONSES;
+        // 为每个请求生成唯一 ID，用于在单例 converter 中隔离并发流状态
+        const streamRequestId = `req_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
 
         for await (const nativeChunk of nativeStream) {
             // 检查客户端是否已断开连接
@@ -360,7 +362,7 @@ export async function handleStreamRequest(res, service, model, requestBody, from
 
             // Convert the complete chunk object to the client's format (fromProvider), if necessary.
             const chunkToSend = needsConversion
-                ? convertData(nativeChunk, 'streamChunk', toProvider, fromProvider, model)
+                ? convertData(nativeChunk, 'streamChunk', toProvider, fromProvider, model, streamRequestId)
                 : nativeChunk;
 
             // 监控钩子：流式响应分块


### PR DESCRIPTION
## fix: 修复 Codex→Claude 流式转换并发串流导致 content_block_start 丢失的问题

### 问题描述

在 OpenClaw 中使用 Codex to Claude 的 Convert 时，偶发性会遇到报错：

```
Cannot read properties of undefined (reading 'type')
```

排查发现是因为 `CodexConverter` 在 `ConverterFactory` 中以单例模式缓存，所有并发请求共享同一个 converter 实例及其 `streamParams` 状态 Map。当多个流式请求同时进行时，`response.created` 事件会互相覆盖 `lastClaudeStreamResponseId` 和 `streamParams` 中的流状态（如 `blockStarted`、`currentBlockType`），导致并发请求时可能会跳过 `content_block_start` 事件。Claude 协议要求严格的事件序列（`message_start → content_block_start → content_block_delta → content_block_stop → message_stop`），缺少 `content_block_start` 后客户端无法建立 block 上下文，进而在处理后续 `content_block_delta` 时因 block 未定义而抛出 `Cannot read properties of undefined (reading 'type')`。

### 修复方案

在 `handleStreamRequest`（`common.js`）中为每个请求生成唯一的 `streamRequestId`，沿 `handleStreamRequest → convertData → convertStreamChunk → toClaudeStreamChunk` 链路透传，使用 `requestId` 替代 `response.id` 作为 `streamParams` 的隔离 key，确保同一单例 converter 上的并发流状态完全独立。同时移除不再需要的 `lastClaudeStreamResponseId` 和 `lastUpdatedAt` 等兜底逻辑，简化状态管理。

### 改动文件

- `src/utils/common.js` — 生成 per-request `streamRequestId` 并传入 `convertData`
- `src/convert/convert.js` — `convertData` 函数签名增加 `requestId` 参数，透传至 `convertStreamChunk`
- `src/converters/strategies/CodexConverter.js` — `toClaudeStreamChunk` 使用 `requestId` 隔离并发流状态

### 影响范围

- 仅影响 Codex→Claude 的流式转换路径
- `convertStreamChunk` 新增的 `requestId` 参数对其他 Converter（OpenAI、Gemini、Grok、Claude、OpenAIResponses）无影响，JS 中多余参数会被自动忽略
- 非流式转换（request、response、modelList）不受影响
