### PR TITLE
fix(grok): avoid blocking the first request on initial usage sync

### DIFF
--- a/src/providers/grok/grok-core.js
+++ b/src/providers/grok/grok-core.js
@@ -155,8 +155,11 @@ export class GrokApiService {
 
     async initialize() {
         if (this.isInitialized) return;
-        try { await this.getUsageLimits(); } catch (error) { logger.warn('[Grok] Initial usage sync failed:', error.message); }
         this.isInitialized = true;
+        this.getUsageLimits()
+            .catch((error) => {
+                logger.warn('[Grok] Initial usage sync failed:', error.message);
+            });
     }
 
     async refreshToken() {


### PR DESCRIPTION
Refs #383

This makes the initial Grok usage sync non-blocking.

Instead of awaiting getUsageLimits() during initialize(), the provider is marked ready first and the initial usage fetch runs in the background with warning-only error handling.

This keeps the first request off the /rest/rate-limits hot path while preserving explicit refresh / later usage fetch behavior.

The only intentional behavior change is that usageData may be briefly unavailable right after first initialization.