### PR TITLE
feat: add Novita AI as an OpenAI-compatible provider

### DIFF
--- a/configs/provider_pools.json.example
+++ b/configs/provider_pools.json.example
@@ -180,6 +180,22 @@
       "lastErrorTime": null
     }
   ],
+  "openai-novita": [
+    {
+      "customName": "Novita AI节点1",
+      "NOVITA_API_KEY": "your-novita-api-key",
+      "NOVITA_BASE_URL": "https://api.novita.ai/openai",
+      "checkModelName": null,
+      "checkHealth": false,
+      "uuid": "c3a1f2b4-d5e6-47f8-9a0b-1c2d3e4f5a6b",
+      "isHealthy": true,
+      "isDisabled": false,
+      "lastUsed": null,
+      "usageCount": 0,
+      "errorCount": 0,
+      "lastErrorTime": null
+    }
+  ],
   "openai-iflow": [
     {
       "customName": "iFlow Token节点1",

--- a/src/providers/adapter.js
+++ b/src/providers/adapter.js
@@ -9,6 +9,7 @@ import { IFlowApiService } from './openai/iflow-core.js';
 import { CodexApiService } from './openai/codex-core.js';
 import { ForwardApiService } from './forward/forward-core.js';
 import { GrokApiService } from './grok/grok-core.js';
+import { NovitaApiService } from './openai/novita-core.js';
 import { MODEL_PROVIDER } from '../utils/common.js';
 import logger from '../utils/logger.js';
 
@@ -688,6 +689,38 @@ export class GrokApiServiceAdapter extends ApiServiceAdapter {
     }
 }
 
+// Novita AI API 服务适配器
+export class NovitaApiServiceAdapter extends ApiServiceAdapter {
+    constructor(config) {
+        super();
+        this.novitaApiService = new NovitaApiService(config);
+    }
+
+    async generateContent(model, requestBody) {
+        return this.novitaApiService.generateContent(model, requestBody);
+    }
+
+    async *generateContentStream(model, requestBody) {
+        yield* this.novitaApiService.generateContentStream(model, requestBody);
+    }
+
+    async listModels() {
+        return this.novitaApiService.listModels();
+    }
+
+    async refreshToken() {
+        return Promise.resolve();
+    }
+
+    async forceRefreshToken() {
+        return Promise.resolve();
+    }
+
+    isExpiryDateNear() {
+        return false;
+    }
+}
+
 // 注册所有内置适配器
 registerAdapter(MODEL_PROVIDER.OPENAI_CUSTOM, OpenAIApiServiceAdapter);
 registerAdapter(MODEL_PROVIDER.OPENAI_CUSTOM_RESPONSES, OpenAIResponsesApiServiceAdapter);
@@ -699,6 +732,7 @@ registerAdapter(MODEL_PROVIDER.QWEN_API, QwenApiServiceAdapter);
 // registerAdapter(MODEL_PROVIDER.IFLOW_API, IFlowApiServiceAdapter);
 registerAdapter(MODEL_PROVIDER.CODEX_API, CodexApiServiceAdapter);
 registerAdapter(MODEL_PROVIDER.GROK_CUSTOM, GrokApiServiceAdapter);
+registerAdapter(MODEL_PROVIDER.NOVITA_CUSTOM, NovitaApiServiceAdapter);
 // registerAdapter(MODEL_PROVIDER.FORWARD_API, ForwardApiServiceAdapter);
 
 // 用于存储服务适配器单例的映射

--- a/src/providers/openai/novita-core.js
+++ b/src/providers/openai/novita-core.js
@@ -1,0 +1,35 @@
+import { OpenAIApiService } from './openai-core.js';
+import { getProviderModels } from '../provider-models.js';
+import { MODEL_PROVIDER } from '../../utils/common.js';
+import logger from '../../utils/logger.js';
+
+const DEFAULT_NOVITA_BASE_URL = 'https://api.novita.ai/openai';
+
+// Novita AI API service — OpenAI-compatible endpoint
+export class NovitaApiService extends OpenAIApiService {
+    constructor(config) {
+        if (!config.NOVITA_API_KEY && !config.OPENAI_API_KEY) {
+            throw new Error("Novita API Key (NOVITA_API_KEY) is required for NovitaApiService.");
+        }
+        const mappedConfig = {
+            ...config,
+            OPENAI_API_KEY: config.NOVITA_API_KEY || config.OPENAI_API_KEY,
+            OPENAI_BASE_URL: config.NOVITA_BASE_URL || config.OPENAI_BASE_URL || DEFAULT_NOVITA_BASE_URL,
+        };
+        super(mappedConfig);
+        logger.info(`[Novita] Initialized with base URL: ${mappedConfig.OPENAI_BASE_URL}`);
+    }
+
+    async listModels() {
+        const models = getProviderModels(MODEL_PROVIDER.NOVITA_CUSTOM);
+        return {
+            object: 'list',
+            data: models.map(id => ({
+                id,
+                object: 'model',
+                created: 1677610602,
+                owned_by: 'novita-ai',
+            })),
+        };
+    }
+}

--- a/src/providers/provider-models.js
+++ b/src/providers/provider-models.js
@@ -90,6 +90,11 @@ export const PROVIDER_MODELS = {
         'gpt-5.4',
     ],
     'forward-api': [],
+    'openai-novita': [
+        'moonshotai/kimi-k2.5',
+        'zai-org/glm-5',
+        'minimax/minimax-m2.5',
+    ],
     'grok-custom': [
         'grok-3',
         'grok-3-mini',

--- a/src/providers/provider-pool-manager.js
+++ b/src/providers/provider-pool-manager.js
@@ -24,6 +24,7 @@ export class ProviderPoolManager {
         'openai-codex-oauth': 'gpt-5-codex-mini',
         'openaiResponses-custom': 'gpt-4o-mini',
         'forward-api': 'gpt-4o-mini',
+        'openai-novita': 'moonshotai/kimi-k2.5',
     };
 
     constructor(providerPools, options = {}) {

--- a/src/services/service-manager.js
+++ b/src/services/service-manager.js
@@ -563,7 +563,8 @@ export async function getProviderStatus(config, options = {}) {
         'gemini-antigravity': 'ANTIGRAVITY_OAUTH_CREDS_FILE_PATH',
         'openai-iflow': 'IFLOW_TOKEN_FILE_PATH',
         'forward-api': 'FORWARD_BASE_URL',
-        'grok-custom': 'GROK_COOKIE_TOKEN'
+        'grok-custom': 'GROK_COOKIE_TOKEN',
+        'openai-novita': 'NOVITA_API_KEY'
     };
     let providerPoolsSlim = [];
     let unhealthyProvideIdentifyList = [];

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -73,6 +73,7 @@ export const MODEL_PROVIDER = {
     CODEX_API: 'openai-codex-oauth',
     FORWARD_API: 'forward-api',
     GROK_CUSTOM: 'grok-custom',
+    NOVITA_CUSTOM: 'openai-novita',
     AUTO: 'auto',
 }
 


### PR DESCRIPTION
## Summary

Adds [Novita AI](https://novita.ai) as a new LLM provider using its OpenAI-compatible API endpoint.

- New provider key: `openai-novita` — uses the `openai` protocol prefix, so all existing OpenAI converters/strategies apply automatically
- Auth: `NOVITA_API_KEY` (or `OPENAI_API_KEY` as fallback), base URL defaults to `https://api.novita.ai/openai`
- Models: `moonshotai/kimi-k2.5`, `zai-org/glm-5`, `minimax/minimax-m2.5`

## Changes

| File | What changed |
|------|-------------|
| `src/providers/openai/novita-core.js` | New core service — extends `OpenAIApiService`, remaps `NOVITA_API_KEY` → `OPENAI_API_KEY`, sets default base URL, returns static model list |
| `src/utils/common.js` | Added `NOVITA_CUSTOM: 'openai-novita'` to `MODEL_PROVIDER` enum |
| `src/providers/adapter.js` | Added `NovitaApiServiceAdapter` class and registered it |
| `src/providers/provider-models.js` | Added `openai-novita` model list |
| `src/providers/provider-pool-manager.js` | Added default health check model for `openai-novita` |
| `src/services/service-manager.js` | Added `openai-novita` → `NOVITA_API_KEY` to `identifyFieldMap` |
| `configs/provider_pools.json.example` | Added sample `openai-novita` pool config entry |

## Configuration

Add to `provider_pools.json`:

```json
"openai-novita": [
  {
    "customName": "Novita AI",
    "NOVITA_API_KEY": "your-novita-api-key",
    "NOVITA_BASE_URL": "https://api.novita.ai/openai"
  }
]
```

API keys can be obtained at https://novita.ai.