### PR TITLE
feat(codex): add gpt-5.4-mini to provider model list

### DIFF
--- a/src/providers/provider-models.js
+++ b/src/providers/provider-models.js
@@ -88,6 +88,8 @@ export const PROVIDER_MODELS = {
         'gpt-5.3-codex',
         'gpt-5.3-codex-spark',
         'gpt-5.4',
+        // 保留 Codex 侧的 mini 变体，避免 UI/校验层把可用模型误判为不存在。
+        'gpt-5.4-mini',
     ],
     'forward-api': [],
     'grok-custom': [

--- a/tests/provider-models.test.js
+++ b/tests/provider-models.test.js
@@ -1,0 +1,9 @@
+import { getProviderModels } from '../src/providers/provider-models.js';
+
+describe('provider models', () => {
+    test('openai-codex-oauth exposes gpt-5.4-mini', () => {
+        const models = getProviderModels('openai-codex-oauth');
+
+        expect(models).toContain('gpt-5.4-mini');
+    });
+});


### PR DESCRIPTION
## 中文
### 变更内容
- 在 `openai-codex-oauth` 的模型列表中补回 `gpt-5.4-mini`
- 补充对应测试，确保 UI / 校验层不会把该模型误判为不存在

### 为什么要改
- 该模型在实际 Codex 路线中是可用的，但模型列表遗漏后会导致前端选择、模型校验和配置展示不一致
- 这是一个低风险的兼容性修复，只影响模型枚举，不改变请求路由和执行逻辑

### 影响范围
- `src/providers/provider-models.js`
- `tests/provider-models.test.js`

## English
### What changed
- Restored `gpt-5.4-mini` in the `openai-codex-oauth` model list
- Added a test so the UI / validation layer does not treat the model as missing

### Why
- The model is actually available in the Codex path, but it was omitted from the provider model table
- That omission causes inconsistent behavior between model selection, validation, and configuration display
- This is a low-risk compatibility fix: it changes model enumeration only, not request routing or execution logic

### Scope
- `src/providers/provider-models.js`
- `tests/provider-models.test.js`
