### PR TITLE
feat(codex): add session-affinity caching for Codex requests

### DIFF
--- a/src/providers/provider-models.js
+++ b/src/providers/provider-models.js
@@ -88,6 +88,8 @@ export const PROVIDER_MODELS = {
         'gpt-5.3-codex',
         'gpt-5.3-codex-spark',
         'gpt-5.4',
+        // 保留 Codex 侧的 mini 变体，避免 UI/校验层把可用模型误判为不存在。
+        'gpt-5.4-mini',
     ],
     'forward-api': [],
     'grok-custom': [

--- a/tests/provider-models.test.js
+++ b/tests/provider-models.test.js
@@ -1,0 +1,9 @@
+import { getProviderModels } from '../src/providers/provider-models.js';
+
+describe('provider models', () => {
+    test('openai-codex-oauth exposes gpt-5.4-mini', () => {
+        const models = getProviderModels('openai-codex-oauth');
+
+        expect(models).toContain('gpt-5.4-mini');
+    });
+});


### PR DESCRIPTION
## 中文
### 变更内容
- 根据 `metadata.session_id` / `conversation_id` / `user_id` 生成会话亲和性键
- 在 provider 选择层固定同一会话尽量命中同一个 Codex 实例
- 在 Codex 侧继续使用会话缓存，并补充可选的调试日志
- 增加配置项 `CODEX_CACHE_DEBUG_LOG`

### 为什么要改
- 现有 Codex 缓存是实例内缓存，同一会话如果被路由到不同实例，缓存命中会不稳定
- 对 Discord 这类场景来说，频道 / 私聊 / 子线程应该尽量保持会话一致性
- 这样可以提高缓存命中率，减少重复 token 消耗，并让行为和上游会话语义保持一致

### 影响范围
- `src/utils/common.js`
- `src/providers/provider-pool-manager.js`
- `src/providers/openai/codex-core.js`
- `src/core/config-manager.js`
- `configs/config.json.example`
- `tests/codex-cache-debug-check.mjs`

## English
### What changed
- Derive a session-affinity key from `metadata.session_id` / `conversation_id` / `user_id`
- Keep the same session pinned to the same Codex instance as much as possible at provider selection time
- Continue using Codex session caching and add optional debug logging
- Add `CODEX_CACHE_DEBUG_LOG` configuration

### Why
- Current Codex caching is instance-local, so the same session can miss cache if requests land on different instances
- For Discord-style workloads, channel / DM / thread traffic should stay session-consistent whenever possible
- This improves cache hit rate, reduces repeated token spend, and aligns behavior with upstream session semantics

### Scope
- `src/utils/common.js`
- `src/providers/provider-pool-manager.js`
- `src/providers/openai/codex-core.js`
- `src/core/config-manager.js`
- `configs/config.json.example`
- `tests/codex-cache-debug-check.mjs`
