### PR TITLE
fix: update TOTAL_CONTEXT_TOKENS to 1M for Kiro context window upgrade

### DIFF
--- a/src/providers/claude/claude-kiro.js
+++ b/src/providers/claude/claude-kiro.js
@@ -44,7 +44,7 @@ const KIRO_CONSTANTS = {
     AUTH_METHOD_SOCIAL: 'social',
     CHAT_TRIGGER_TYPE_MANUAL: 'MANUAL',
     ORIGIN_AI_EDITOR: 'AI_EDITOR',
-    TOTAL_CONTEXT_TOKENS: 172500, // 总上下文 173k tokens
+    TOTAL_CONTEXT_TOKENS: 1000000, // Kiro now supports 1M context window
 };
 
 // 从 provider-models.js 获取支持的模型列表


### PR DESCRIPTION
Kiro has upgraded its context window from 173k to 1M tokens. The hardcoded `TOTAL_CONTEXT_TOKENS: 172500` causes `input_tokens` in the converted Claude SSE response to be severely underestimated (~17% of actual value).

## Problem

`input_tokens` is calculated as:
```
totalTokens = TOTAL_CONTEXT_TOKENS * contextUsagePercentage / 100
inputTokens = totalTokens - outputTokens
```

With the old `172500` constant, a request with real input of ~170k tokens gets reported as ~35k tokens, causing downstream billing systems to undercharge by ~5x.

## Fix

Update `TOTAL_CONTEXT_TOKENS` from `172500` to `1000000` to match Kiro's current 1M context window.