### PR TITLE
fix(ui): 移除弹窗 backdrop-filter blur 修复 UI 卡顿

### DIFF
--- a/static/app/mobile.css
+++ b/static/app/mobile.css
@@ -56,7 +56,7 @@
     left: 0;
     right: 0;
     bottom: 0;
-    background: rgba(0, 0, 0, 0.5);
+    background: var(--overlay-bg);
     z-index: 99;
     opacity: 0;
     transition: opacity 0.3s ease;

--- a/static/app/provider-manager.js
+++ b/static/app/provider-manager.js
@@ -554,9 +554,7 @@ function showSimplePrompt(title, placeholder, callback) {
     overlay.className = 'modal-overlay';
     overlay.style.display = 'flex';
     overlay.style.zIndex = '3000';
-    overlay.style.background = 'rgba(0, 0, 0, 0.2)';
-    overlay.style.backdropFilter = 'blur(2px)';
-    
+
     overlay.innerHTML = `
         <div class="modal-content" style="max-width: 320px; border-radius: 12px; box-shadow: 0 10px 25px rgba(0,0,0,0.1); border: 1px solid var(--border-color); padding: 20px;">
             <div style="margin-bottom: 12px; font-weight: 600; font-size: 14px; color: var(--text-primary);">${title}</div>

--- a/static/components/section-providers.css
+++ b/static/components/section-providers.css
@@ -413,9 +413,7 @@
     left: 0;
     width: 100%;
     height: 100%;
-    background: rgba(0, 0, 0, 0.4);
-    backdrop-filter: blur(8px);
-    -webkit-backdrop-filter: blur(8px);
+    background: var(--overlay-bg);
     display: flex;
     justify-content: center;
     align-items: center;
@@ -1343,7 +1341,6 @@
     width: 100%;
     height: 100%;
     background: var(--overlay-bg);
-    backdrop-filter: blur(4px);
     display: none;
     justify-content: center;
     align-items: center;

--- a/static/components/section-upload-config.css
+++ b/static/components/section-upload-config.css
@@ -497,7 +497,6 @@
     position: fixed;
     top: 0; left: 0; width: 100%; height: 100%;
     background: var(--overlay-bg);
-    backdrop-filter: blur(4px);
     display: flex; justify-content: center; align-items: center;
     z-index: 1000; opacity: 0; visibility: hidden;
     transition: all 0.3s ease;
@@ -660,7 +659,7 @@
 /* 删除确认模态框样式 */
 .delete-confirm-modal {
     position: fixed; top: 0; left: 0; width: 100%; height: 100%;
-    background: var(--overlay-bg); backdrop-filter: blur(4px);
+    background: var(--overlay-bg);
     display: flex; justify-content: center; align-items: center;
     z-index: 1000; opacity: 0; visibility: hidden;
     transition: all 0.3s ease;


### PR DESCRIPTION
## 问题

所有模态弹窗（Provider 管理、认证选择器、添加分组等）打开时都会出现明显的 UI 卡顿和掉帧。根因是 `backdrop-filter: blur()` 强制 GPU 对整个视口背景进行模糊计算，在高 DPI 屏幕或复杂页面布局下会导致帧率骤降。

## 修复

1. **移除所有 `backdrop-filter: blur()`** — 从模态弹窗的 CSS 类和 JS 内联样式中彻底删除。弹窗保留半透明深色背景（`var(--overlay-bg)`），视觉差异极小但性能提升显著。

2. **统一遮罩层背景透明度** — 将硬编码的 `rgba()` 值统一替换为已有的 CSS 自定义变量 `var(--overlay-bg)`（亮色模式 0.6，暗色模式 0.8），确保所有弹窗外观一致。

## 变更文件

| 文件 | 改动 |
|------|------|
| `static/components/section-providers.css` | 移除 `.provider-modal` 的 `blur(8px)` 和 `.modal-overlay` 的 `blur(4px)` |
| `static/components/section-upload-config.css` | 移除上传配置弹窗和删除确认弹窗的 `blur(4px)` |
| `static/app/provider-manager.js` | 移除 `showSimplePrompt()` 中的内联 `backdropFilter: blur(2px)` |
| `static/app/mobile.css` | 将 `.mobile-overlay` 的硬编码 `rgba(0,0,0,0.5)` 替换为 `var(--overlay-bg)` |

## 影响范围

- 4 个文件变更，+4 行，-10 行
- 无功能变更 — 弹窗仍保留半透明深色背景
- 未修改任何 JS 业务逻辑
- 安全合并

---

**Author: Jarvis-Drawf**