### PR TITLE
fix: set Opus MODEL_CONTEXT_TOKENS to 200K to match Claude Code client

### DIFF
--- a/src/providers/claude/claude-kiro.js
+++ b/src/providers/claude/claude-kiro.js
@@ -49,9 +49,9 @@ const KIRO_CONSTANTS = {
 
 // Per-model context window sizes for accurate token estimation
 const MODEL_CONTEXT_TOKENS = {
-    "claude-opus-4-6": 1000000,
-    "claude-opus-4-5": 1000000,
-    "claude-opus-4-5-20251101": 1000000,
+    "claude-opus-4-6": 200000,
+    "claude-opus-4-5": 200000,
+    "claude-opus-4-5-20251101": 200000,
     "claude-sonnet-4-6": 200000,
     "claude-sonnet-4-5": 200000,
     "claude-sonnet-4-5-20250929": 200000,


### PR DESCRIPTION
## Summary

Fixes #490

Opus models (`claude-opus-4-6`, `claude-opus-4-5`, `claude-opus-4-5-20251101`) had `MODEL_CONTEXT_TOKENS` set to `1000000` (1M), but Claude Code client assumes a 200K context window.

The token calculation `contextTokens * contextUsagePercentage / 100` produces inflated `input_tokens` values (e.g. 147K for a single hi message), causing immediate autocompact thrashing and making Opus models completely unusable in Claude Code.

## Changes

- `src/providers/claude/claude-kiro.js`: Changed Opus `MODEL_CONTEXT_TOKENS` from `1000000` to `200000` (3 lines)

## Before / After

| Metric | Before | After |
|--------|--------|-------|
| Context after sending hi | 158.5k/200k (79%) | 31.7k/200k (16%) |
| Messages token delta | +135.6k | +8.8k |
| Autocompact thrashing | Yes (unusable) | No (normal) |

## Test

1. Start AIClient2API, open Claude Code with Opus model
2. `/context` -> 22.9k (12%)
3. Send `hi`
4. `/context` -> 31.7k (16%) (was 158.5k before fix)