### PR TITLE
fix: fallback to Kiro IDE cache when refresh fails (#523)

### DIFF
--- a/src/providers/claude/claude-kiro.js
+++ b/src/providers/claude/claude-kiro.js
@@ -114,6 +114,118 @@ const MODEL_MAPPING = Object.fromEntries(
 
 const KIRO_AUTH_TOKEN_FILE = "kiro-auth-token.json";
 
+// Kiro IDE source credentials cache directory (~/.aws/sso/cache/)
+const KIRO_IDE_CACHE_DIR = path.join(os.homedir(), '.aws', 'sso', 'cache');
+
+/**
+ * Sync credentials from Kiro IDE source files (~/.aws/sso/cache/).
+ *
+ * Kiro IDE continuously refreshes OAuth tokens in the background. When the proxy's
+ * refresh token is invalidated (e.g., consumed by Kiro IDE due to the one-time-use
+ * nature of AWS IAM Identity Center refresh tokens), this function provides a
+ * fallback recovery path by reading the latest token directly from Kiro IDE's cache.
+ *
+ * The Kiro IDE cache stores credentials in two files:
+ *   - kiro-auth-token.json: accessToken, refreshToken, expiresAt, profileArn
+ *   - <hash>.json: clientId, clientSecret (client registration, ~90 day lifetime)
+ *
+ * Both files are merged and written back to the proxy's credential file.
+ *
+ * @param {string} proxyCredFilePath - Path to the proxy's credential file to update
+ * @returns {Object|null} Merged credentials object, or null if sync is not possible
+ */
+async function syncFromKiroIDE(proxyCredFilePath) {
+    try {
+        let cacheFiles;
+        try {
+            cacheFiles = (await fs.readdir(KIRO_IDE_CACHE_DIR)).filter(f => f.endsWith('.json'));
+        } catch (e) {
+            logger.debug(`[Kiro Sync] Cannot read Kiro IDE cache dir: ${e.message}`);
+            return null;
+        }
+
+        // Find the most recently modified token file (has accessToken + refreshToken)
+        let tokenContent = null;
+        let tokenFileName = null;
+        let latestMtime = 0;
+        for (const f of cacheFiles) {
+            const fp = path.join(KIRO_IDE_CACHE_DIR, f);
+            try {
+                const stat = await fs.stat(fp);
+                const raw = await fs.readFile(fp, 'utf8');
+                const parsed = JSON.parse(raw);
+                if (parsed.accessToken && parsed.refreshToken && stat.mtimeMs > latestMtime) {
+                    tokenContent = parsed;
+                    tokenFileName = f;
+                    latestMtime = stat.mtimeMs;
+                }
+            } catch { /* skip unreadable files */ }
+        }
+
+        // Find clientId + clientSecret from a separate client registration file
+        let clientId = null;
+        let clientSecret = null;
+        for (const f of cacheFiles) {
+            try {
+                const raw = await fs.readFile(path.join(KIRO_IDE_CACHE_DIR, f), 'utf8');
+                const parsed = JSON.parse(raw);
+                if (parsed.clientId && parsed.clientSecret) {
+                    clientId = parsed.clientId;
+                    clientSecret = parsed.clientSecret;
+                    break;
+                }
+            } catch { /* skip */ }
+        }
+
+        if (!tokenContent || !clientId) {
+            logger.debug('[Kiro Sync] No valid source token or client registration found in Kiro IDE cache');
+            return null;
+        }
+
+        // Check if the source token itself is still valid (not expired)
+        if (tokenContent.expiresAt) {
+            const expiresAt = new Date(tokenContent.expiresAt);
+            if (expiresAt <= new Date()) {
+                logger.warn(`[Kiro Sync] Kiro IDE source token is also expired (${tokenContent.expiresAt}), cannot recover`);
+                return null;
+            }
+        }
+
+        // Merge credentials from both files
+        const merged = {
+            accessToken: tokenContent.accessToken,
+            refreshToken: tokenContent.refreshToken,
+            expiresAt: tokenContent.expiresAt,
+            clientId,
+            clientSecret,
+        };
+        if (tokenContent.profileArn) merged.profileArn = tokenContent.profileArn;
+        if (tokenContent.authMethod) merged.authMethod = tokenContent.authMethod;
+        if (tokenContent.region) merged.region = tokenContent.region;
+
+        // Write merged credentials to the proxy's credential file
+        if (proxyCredFilePath) {
+            try {
+                let existingData = {};
+                try {
+                    const raw = await fs.readFile(proxyCredFilePath, 'utf8');
+                    existingData = JSON.parse(raw);
+                } catch { /* file may not exist yet */ }
+                const updatedData = { ...existingData, ...merged };
+                await fs.writeFile(proxyCredFilePath, JSON.stringify(updatedData, null, 2), 'utf8');
+                logger.info(`[Kiro Sync] Synced credentials to ${proxyCredFilePath} (source: ${tokenFileName})`);
+            } catch (writeErr) {
+                logger.warn(`[Kiro Sync] Failed to write proxy credential file: ${writeErr.message}`);
+            }
+        }
+
+        return merged;
+    } catch (error) {
+        logger.warn(`[Kiro Sync] Failed to sync from Kiro IDE: ${error.message}`);
+        return null;
+    }
+}
+
 /**
  * Kiro API Service - Node.js implementation based on the Python ki2api
  * Provides OpenAI-compatible API for Claude Sonnet 4 via Kiro/CodeWhisperer
@@ -650,6 +762,30 @@ async loadCredentials() {
         this.refreshUrl = (this.config.KIRO_REFRESH_URL || KIRO_CONSTANTS.REFRESH_URL).replace("{{region}}", this.region);
         this.refreshIDCUrl = (this.config.KIRO_REFRESH_IDC_URL || KIRO_CONSTANTS.REFRESH_IDC_URL).replace("{{region}}", this.idcRegion);
         this.baseUrl = (this.config.KIRO_BASE_URL || KIRO_CONSTANTS.BASE_URL).replace("{{region}}", this.region);
+
+        // Auto-sync from Kiro IDE cache if the loaded token is already expired.
+        // This handles the case where users upload credentials that have since
+        // been rotated by Kiro IDE's background refresh.
+        if (this.expiresAt) {
+            const expiresAt = new Date(this.expiresAt);
+            if (expiresAt <= new Date()) {
+                logger.warn('[Kiro Auth] Loaded token is expired (' + this.expiresAt + '), attempting sync from Kiro IDE...');
+                const tokenFilePath = this.credsFilePath || path.join(this.credPath, KIRO_AUTH_TOKEN_FILE);
+                const synced = await syncFromKiroIDE(tokenFilePath);
+                if (synced) {
+                    this.accessToken = synced.accessToken;
+                    this.refreshToken = synced.refreshToken;
+                    this.expiresAt = synced.expiresAt;
+                    if (synced.clientId) this.clientId = synced.clientId;
+                    if (synced.clientSecret) this.clientSecret = synced.clientSecret;
+                    if (synced.profileArn) this.profileArn = synced.profileArn;
+                    if (synced.region) this.region = synced.region;
+                    logger.info('[Kiro Auth] Startup sync from Kiro IDE successful');
+                } else {
+                    logger.warn('[Kiro Auth] Startup sync from Kiro IDE failed, credentials remain expired');
+                }
+            }
+        }
     } catch (error) {
         logger.warn(`[Kiro Auth] Error during credential loading: ${error.message}`);
     }
@@ -798,6 +934,34 @@ async saveCredentialsToFile(filePath, newData) {
             }
         } catch (error) {
             logger.error('[Kiro Auth] Token refresh failed:', error.message);
+
+            // Fallback: attempt to recover by syncing from Kiro IDE source files.
+            // This handles the common case where the refresh token has been consumed
+            // by Kiro IDE (AWS IAM Identity Center refresh tokens are one-time use).
+            logger.info('[Kiro Auth] Attempting fallback recovery from Kiro IDE source files...');
+            const synced = await syncFromKiroIDE(tokenFilePath);
+            if (synced) {
+                this.accessToken = synced.accessToken;
+                this.refreshToken = synced.refreshToken;
+                this.expiresAt = synced.expiresAt;
+                if (synced.clientId) this.clientId = synced.clientId;
+                if (synced.clientSecret) this.clientSecret = synced.clientSecret;
+                if (synced.profileArn) this.profileArn = synced.profileArn;
+                logger.info('[Kiro Auth] Fallback recovery successful, credentials restored from Kiro IDE');
+
+                // Reset the pool manager's refresh status since we recovered
+                const poolManager = getProviderPoolManager();
+                if (poolManager && this.uuid) {
+                    poolManager.resetProviderRefreshStatus(
+                        this.config.MODEL_PROVIDER || MODEL_PROVIDER.KIRO_API,
+                        this.uuid
+                    );
+                }
+                return; // Recovered successfully, suppress the error
+            }
+
+            // Both native refresh and Kiro IDE fallback failed
+            logger.error('[Kiro Auth] Kiro IDE fallback also failed, no recovery possible');
             throw new Error(`Token refresh failed: ${error.message}`);
         }
     }


### PR DESCRIPTION
﻿修复 #523 中的 Kiro OAuth 凭证自动恢复问题。

## 问题

AWS IAM Identity Center 的 refresh token 是一次性使用的。反代和 Kiro IDE 共用凭证时，Kiro IDE 后台刷新会抢先消费 refresh token，反代刷新失败后凭证被永久标记 unhealthy，用户只能手动改 `provider_pools.json` 脱困。

## 方案

本 PR 不改核心 unhealthy 判定逻辑，而是利用 Kiro IDE 会持续在 `~/.aws/sso/cache/` 维护最新 token 这一事实，提供 fallback 恢复路径。

## 修改（`src/providers/claude/claude-kiro.js`，+164 行）

1. 新增 `syncFromKiroIDE()` 函数：从 `~/.aws/sso/cache/` 读取最新 token + client registration，合并后写入反代凭证文件
2. `_doTokenRefresh` catch 块：refresh 失败时尝试 `syncFromKiroIDE` 恢复，成功则重置 pool 状态并 return，失败才 throw
3. `loadCredentials` 末尾：启动时若加载的 token 已过期，自动同步（解决首次上传过期凭证的问题）

## 效果

| 场景 | PR 前 | PR 后 |
|------|-------|-------|
| 反代独立运行 | 正常 | 正常（无变化） |
| 反代 + Kiro IDE 共存，refresh 被抢 | 挂掉需手动干预 | 自动从源文件恢复 |
| 首次上传已过期凭证 | 启动即挂 | 启动时自动同步 |

## 兼容性

- 只影响 Kiro OAuth，其他 provider 完全不受影响
- 正常流程下 fallback 不触发，无开销
- 仅用 Node.js 内置模块，无新增依赖

Refs: #523
