### PR TITLE
fix: add provider pool file fallback for usage API and support remainingPercent display

### DIFF
--- a/src/ui-modules/usage-api.js
+++ b/src/ui-modules/usage-api.js
@@ -5,6 +5,7 @@ import { formatKiroUsage, formatGeminiUsage, formatAntigravityUsage, formatCodex
 import { readUsageCache, writeUsageCache, readProviderUsageCache, updateProviderUsageCache } from './usage-cache.js';
 import { PROVIDER_MAPPINGS } from '../utils/provider-utils.js';
 import path from 'path';
+import { existsSync, readFileSync } from 'fs';
 
 const supportedProviders = ['claude-kiro-oauth', 'gemini-cli-oauth', 'gemini-antigravity', 'openai-codex-oauth', 'grok-custom'];
 
@@ -50,6 +51,37 @@ async function getAllProvidersUsage(currentConfig, providerPoolManager) {
 }
 
 /**
+ * 加载提供商池数据（从内存或文件）
+ * @param {string} providerType - 提供商类型
+ * @param {Object} currentConfig - 当前配置
+ * @param {Object} providerPoolManager - 提供商池管理器
+ * @returns {Array} 提供商列表
+ */
+function loadProviderList(providerType, currentConfig, providerPoolManager) {
+    // 优先从内存获取
+    if (providerPoolManager && providerPoolManager.providerPools && providerPoolManager.providerPools[providerType]) {
+        return providerPoolManager.providerPools[providerType];
+    }
+    if (currentConfig.providerPools && currentConfig.providerPools[providerType]) {
+        return currentConfig.providerPools[providerType];
+    }
+    // Fallback: 从文件读取
+    const filePath = currentConfig.PROVIDER_POOLS_FILE_PATH || 'configs/provider_pools.json';
+    try {
+        if (existsSync(filePath)) {
+            const poolsData = JSON.parse(readFileSync(filePath, 'utf-8'));
+            if (poolsData[providerType] && poolsData[providerType].length > 0) {
+                logger.info(`[Usage API] Loaded ${poolsData[providerType].length} providers for ${providerType} from file fallback`);
+                return poolsData[providerType];
+            }
+        }
+    } catch (fileError) {
+        logger.warn(`[Usage API] Failed to load provider pools from file: ${fileError.message}`);
+    }
+    return [];
+}
+
+/**
  * 获取指定提供商类型的用量信息
  * @param {string} providerType - 提供商类型
  * @param {Object} currentConfig - 当前配置
@@ -65,13 +97,8 @@ async function getProviderTypeUsage(providerType, currentConfig, providerPoolMan
         errorCount: 0
     };
 
-    // 获取提供商池中的所有实例
-    let providers = [];
-    if (providerPoolManager && providerPoolManager.providerPools && providerPoolManager.providerPools[providerType]) {
-        providers = providerPoolManager.providerPools[providerType];
-    } else if (currentConfig.providerPools && currentConfig.providerPools[providerType]) {
-        providers = currentConfig.providerPools[providerType];
-    }
+    // 获取提供商池中的所有实例（使用统一的加载函数）
+    const providers = loadProviderList(providerType, currentConfig, providerPoolManager);
 
     result.totalCount = providers.length;
 

--- a/static/app/usage-manager.js
+++ b/static/app/usage-manager.js
@@ -7,10 +7,10 @@ import { t, getCurrentLanguage } from './i18n.js';
 /**
  * 不支持显示用量数据的提供商列表
  * 这些提供商只显示模型名称和重置时间，不显示用量数字和进度条
+ * 
+ * 注：gemini-antigravity 已支持 remainingPercent，移除限制
  */
-const PROVIDERS_WITHOUT_USAGE_DISPLAY = [
-    'gemini-antigravity'
-];
+const PROVIDERS_WITHOUT_USAGE_DISPLAY = [];
 
 // 提供商配置缓存
 let currentProviderConfigs = null;
@@ -702,21 +702,34 @@ function createUsageBreakdownHTML(breakdown, providerType) {
     // 检查是否应该显示用量信息
     const showUsage = shouldShowUsage(providerType);
 
-    const usagePercent = breakdown.usageLimit > 0
-        ? Math.min(100, (breakdown.currentUsage / breakdown.usageLimit) * 100)
-        : 0;
+    // 优先使用 remainingPercent（antigravity 等提供商提供）
+    const hasRemainingPct = breakdown.remainingPercent !== undefined && breakdown.remainingPercent !== null;
+    const usagePercent = hasRemainingPct
+        ? (100 - breakdown.remainingPercent)
+        : (breakdown.usageLimit > 0
+            ? Math.min(100, (breakdown.currentUsage / breakdown.usageLimit) * 100)
+            : 0);
+    const remainingPercent = hasRemainingPct ? breakdown.remainingPercent : (100 - usagePercent);
     
-    const progressClass = usagePercent >= 90 ? 'danger' : (usagePercent >= 70 ? 'warning' : 'normal');
+    const progressClass = remainingPercent <= 10 ? 'danger' : (remainingPercent <= 30 ? 'warning' : 'normal');
+
+    // 显示格式：如果有 remainingPercent，显示剩余百分比；否则显示已用/总量
+    let usageDisplay = '';
+    if (hasRemainingPct) {
+        usageDisplay = `<span class="breakdown-usage">${remainingPercent}%</span>`;
+    } else if (showUsage && breakdown.usageLimit > 0) {
+        usageDisplay = `<span class="breakdown-usage">${formatNumber(breakdown.currentUsage)} / ${formatNumber(breakdown.usageLimit)}</span>`;
+    }
 
     let html = `
         <div class="breakdown-item-compact">
             <div class="breakdown-header-compact">
-                <span class="breakdown-name">${breakdown.displayName || breakdown.resourceType}</span>
-                ${showUsage ? `<span class="breakdown-usage">${formatNumber(breakdown.currentUsage)} / ${formatNumber(breakdown.usageLimit)}</span>` : ''}
+                <span class="breakdown-name">${breakdown.displayName || breakdown.modelName || breakdown.resourceType}</span>
+                ${usageDisplay}
             </div>
             ${showUsage ? `
             <div class="progress-bar-small ${progressClass}">
-                <div class="progress-fill" style="width: ${usagePercent}%"></div>
+                <div class="progress-fill" style="width: ${remainingPercent}%"></div>
             </div>
             ` : ''}
     `;


### PR DESCRIPTION
### 问题背景

1. **服务重启后用量查询为空**：`usage-api.js` 只从内存中的 `providerPoolManager` 获取 provider 列表，如果服务刚启动或 provider pool 未加载到内存，用量查询返回空结果。

2. **gemini-antigravity 用量显示被禁用**：前端 `usage-manager.js` 将 `gemini-antigravity` 列入 `PROVIDERS_WITHOUT_USAGE_DISPLAY`，但实际上后端 `usage-service.js` 的 `formatAntigravityUsage` 已经支持返回 `remainingPercent` 字段。

3. **进度条逻辑不一致**：进度条显示"使用百分比"（usagePercent），但对于 antigravity 等提供 `remainingPercent` 的提供商，应显示"剩余百分比"更直观。

### 修改内容

**src/ui-modules/usage-api.js**
- 新增 `loadProviderList()` 函数，优先从内存获取 provider 列表，fallback 从 `provider_pools.json` 文件读取
- 确保即使服务未完全初始化也能查询到已配置的账号

**static/app/usage-manager.js**
- 移除 `gemini-antigravity` 的 `PROVIDERS_WITHOUT_USAGE_DISPLAY` 限制（已支持 `remainingPercent`）
- 进度条改为基于 `remainingPercent`（剩余百分比），而非 `usagePercent`
- 显示格式：有 `remainingPercent` 时显示剩余百分比；否则显示"已用/总量"
- 进度条颜色：剩余 ≤10% 红色，≤30% 黄色

### 测试验证

本地部署测试通过：
- 服务重启后用量查询正常返回账号列表
- gemini-antigravity 账号的用量进度条正确显示剩余百分比