### PR TITLE
fix: inherit global proxy settings in provider health checks

### DIFF
--- a/src/providers/provider-pool-manager.js
+++ b/src/providers/provider-pool-manager.js
@@ -2238,9 +2238,11 @@ export class ProviderPoolManager {
 
         // ========== 实际 API 健康检查（带超时保护）==========
         const tempConfig = {
+            ...this.globalConfig,
             ...providerConfig,
             MODEL_PROVIDER: providerType
         };
+        delete tempConfig.providerPools;
         const serviceAdapter = getServiceAdapter(tempConfig);
 
         // 获取所有可能的请求格式


### PR DESCRIPTION
## Summary
- Make provider health checks build their temporary adapter config from global config plus provider-local config, matching refresh/model-list paths.
- Keep provider-local settings as overrides and remove `providerPools` before constructing the adapter.

## Why
When a deployment relies on global proxy/TLS settings, scheduled health checks could bypass those settings because `_checkProviderHealth()` only passed the provider config into `getServiceAdapter()`. This could cause direct egress attempts or false unhealthy results for providers that otherwise work through the configured global proxy.

## Validation
- `node --check src/providers/provider-pool-manager.js`
- `git diff --check`

Note: `npm ci` is currently blocked on upstream package/package-lock mismatch (`axios`, `follow-redirects`, `form-data`, `proxy-from-env`).