### PR TITLE
fix: preserve single-turn Kiro requests

### DIFF
--- a/src/providers/claude/claude-kiro.js
+++ b/src/providers/claude/claude-kiro.js
@@ -977,7 +977,10 @@ async saveCredentialsToFile(filePath, newData) {
             systemPrompt = `${builtInPrefix}`;
         }
         
-        const processedMessages = messages;
+        const processedMessages = messages.map(message => ({
+            ...message,
+            content: Array.isArray(message.content) ? [...message.content] : message.content
+        }));
 
         if (processedMessages.length === 0) {
             throw new Error('No user messages found');
@@ -1148,10 +1151,15 @@ async saveCredentialsToFile(filePath, newData) {
         const history = [];
         let startIndex = 0;
 
+        let prependSystemToCurrentMessage = false;
+
         // Handle system prompt
         if (systemPrompt) {
-            // If the first message is a user message, prepend system prompt to it
-            if (processedMessages[0].role === 'user') {
+            // Keep single-turn requests as a single current message. Duplicating the same user
+            // payload into history and currentMessage can make Kiro reject large agent prompts.
+            if (processedMessages[0].role === 'user' && processedMessages.length === 1) {
+                prependSystemToCurrentMessage = true;
+            } else if (processedMessages[0].role === 'user') {
                 let firstUserContent = this.getContentText(processedMessages[0]);
                 history.push({
                     userInputMessage: {
@@ -1387,6 +1395,12 @@ async saveCredentialsToFile(filePath, newData) {
             // Kiro API 要求 content 不能为空，即使有 toolResults
             if (!currentContent) {
                 currentContent = currentToolResults.length > 0 ? 'Tool results provided.' : 'Continue';
+            }
+
+            if (prependSystemToCurrentMessage) {
+                currentContent = currentContent
+                    ? `${systemPrompt}\n\n${currentContent}`
+                    : systemPrompt;
             }
         }
 

--- a/tests/claude-kiro-request.test.js
+++ b/tests/claude-kiro-request.test.js
@@ -1,0 +1,73 @@
+import { execFileSync } from 'child_process';
+
+describe('Kiro CodeWhisperer request conversion', () => {
+    test('keeps single-turn user requests out of history', async () => {
+        execFileSync(process.execPath, ['--input-type=module', '-e', `
+            import { KiroApiService } from './src/providers/claude/claude-kiro.js';
+
+            const service = new KiroApiService();
+            const inputMessages = [
+                { role: 'user', content: 'hello' }
+            ];
+
+            const request = await service.buildCodewhispererRequest(
+                inputMessages,
+                'claude-opus-4-7',
+                null,
+                'system prompt'
+            );
+
+            if (request.conversationState.history !== undefined) {
+                throw new Error('single-turn request unexpectedly has history');
+            }
+
+            const content = request.conversationState.currentMessage.userInputMessage.content;
+            if (!content.includes('system prompt') || !content.includes('hello')) {
+                throw new Error('current message missing expected content');
+            }
+
+            if (JSON.stringify(inputMessages) !== JSON.stringify([{ role: 'user', content: 'hello' }])) {
+                throw new Error('input messages were mutated');
+            }
+
+            process.exit(0);
+        `], { cwd: process.cwd(), stdio: 'pipe' });
+    });
+
+    test('keeps prior turns in history for multi-turn requests', async () => {
+        execFileSync(process.execPath, ['--input-type=module', '-e', `
+            import { KiroApiService } from './src/providers/claude/claude-kiro.js';
+
+            const service = new KiroApiService();
+            const request = await service.buildCodewhispererRequest(
+                [
+                    { role: 'user', content: 'first' },
+                    { role: 'assistant', content: 'second' },
+                    { role: 'user', content: 'third' }
+                ],
+                'claude-opus-4-7',
+                null,
+                'system prompt'
+            );
+
+            const history = request.conversationState.history;
+            if (!Array.isArray(history) || history.length !== 2) {
+                throw new Error('multi-turn history length changed');
+            }
+
+            if (!history[0].userInputMessage?.content.includes('first')) {
+                throw new Error('first user turn missing from history');
+            }
+
+            if (history[1].assistantResponseMessage?.content !== 'second') {
+                throw new Error('assistant turn missing from history');
+            }
+
+            if (request.conversationState.currentMessage.userInputMessage.content !== 'third') {
+                throw new Error('current message changed');
+            }
+
+            process.exit(0);
+        `], { cwd: process.cwd(), stdio: 'pipe' });
+    });
+});


### PR DESCRIPTION
## Summary

Fix Kiro CodeWhisperer request conversion for single-turn Claude-compatible requests that include a system prompt.

Previously, `buildCodewhispererRequest()` always moved the first user message into `conversationState.history` when a system prompt existed. For single-turn requests, the same user payload was then also used as `currentMessage`, and the adapter inserted a synthetic assistant `Continue` history entry so history ended with an assistant response.

That produces malformed Kiro payloads for large agent prompts and tool-enabled requests, commonly surfacing from Kiro as:

```text
400 {"message":"Improperly formed request.","reason":null}
```

The fix keeps single-turn requests as a single `currentMessage.userInputMessage` and prepends the system prompt there. Multi-turn requests keep the previous history behavior.

## Related reports

- #395 contains multiple reports of Kiro Sonnet/Opus 400s and request-format concerns.
- #150 and #154 previously fixed other Kiro 400 cases around long context / image history. This PR is narrower: it fixes malformed history construction for single-turn requests.

## Verification

- Added regression coverage for single-turn and multi-turn Kiro request conversion.
- Ran:

```bash
npm test -- --runTestsByPath tests/claude-kiro-request.test.js
```

- Also verified against a deployed Kiro-backed instance: the same single-turn `system + user + tools` request returned 400 before this patch and 200 after applying it.
