### PR TITLE
fix: improve Kiro request compatibility

### DIFF
--- a/src/providers/claude/claude-kiro.js
+++ b/src/providers/claude/claude-kiro.js
@@ -48,6 +48,92 @@ const KIRO_CONSTANTS = {
     TOTAL_CONTEXT_TOKENS: 200000, // Claude Sonnet 4.5 actual context is 200K
 };
 
+const KIRO_MAX_TOOL_NAME_LENGTH = 64;
+let kiroThrottleQueue = Promise.resolve();
+let kiroLastRequestStartedAt = 0;
+
+function shortenKiroToolName(name) {
+    const rawName = String(name || '');
+    if (rawName.length <= KIRO_MAX_TOOL_NAME_LENGTH) {
+        return rawName;
+    }
+
+    const hash = crypto.createHash('sha256').update(rawName).digest('hex').slice(0, 12);
+    const prefixLength = KIRO_MAX_TOOL_NAME_LENGTH - hash.length - 1;
+    return `${rawName.slice(0, prefixLength)}_${hash}`;
+}
+
+function buildKiroToolNameMaps(tools) {
+    const aliasToOriginal = new Map();
+    const originalToAlias = new Map();
+
+    if (Array.isArray(tools)) {
+        for (const tool of tools) {
+            const originalName = tool?.name;
+            if (!originalName) continue;
+            const aliasName = shortenKiroToolName(originalName);
+            originalToAlias.set(originalName, aliasName);
+            if (aliasName !== originalName) {
+                aliasToOriginal.set(aliasName, originalName);
+            }
+        }
+    }
+
+    return {
+        aliasToOriginal,
+        toKiroName: (name) => originalToAlias.get(name) || shortenKiroToolName(name),
+        fromKiroName: (name) => aliasToOriginal.get(name) || name
+    };
+}
+
+function restoreKiroToolCallNames(toolCalls, toolNameMaps) {
+    if (!toolCalls || !toolNameMaps?.fromKiroName) {
+        return toolCalls;
+    }
+
+    return toolCalls.map(toolCall => ({
+        ...toolCall,
+        function: {
+            ...toolCall.function,
+            name: toolNameMaps.fromKiroName(toolCall.function?.name)
+        }
+    }));
+}
+
+function getKiroRequestMinIntervalMs(config) {
+    const value = Number(config?.KIRO_REQUEST_MIN_INTERVAL_MS);
+    return Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
+}
+
+async function acquireKiroRequestSlot(config) {
+    const minIntervalMs = getKiroRequestMinIntervalMs(config);
+    if (minIntervalMs <= 0) {
+        return () => {};
+    }
+
+    let releaseCurrent;
+    const previous = kiroThrottleQueue.catch(() => {});
+    kiroThrottleQueue = previous.then(() => new Promise(resolve => {
+        releaseCurrent = resolve;
+    }));
+
+    await previous;
+
+    const elapsedMs = Date.now() - kiroLastRequestStartedAt;
+    const waitMs = Math.max(0, minIntervalMs - elapsedMs);
+    if (waitMs > 0) {
+        await new Promise(resolve => setTimeout(resolve, waitMs));
+    }
+    kiroLastRequestStartedAt = Date.now();
+
+    let released = false;
+    return () => {
+        if (released) return;
+        released = true;
+        releaseCurrent();
+    };
+}
+
 function normalizeKiroToolInput(input) {
     if (input === undefined || input === null) {
         return '';
@@ -977,7 +1063,10 @@ async saveCredentialsToFile(filePath, newData) {
             systemPrompt = `${builtInPrefix}`;
         }
         
-        const processedMessages = messages;
+        const processedMessages = messages.map(message => ({
+            ...message,
+            content: Array.isArray(message.content) ? [...message.content] : message.content
+        }));
 
         if (processedMessages.length === 0) {
             throw new Error('No user messages found');
@@ -1039,6 +1128,7 @@ async saveCredentialsToFile(filePath, newData) {
         processedMessages.push(...mergedMessages);
 
         const codewhispererModel = MODEL_MAPPING[model] || model;
+        const toolNameMaps = buildKiroToolNameMaps(tools);
         
         // 动态压缩 tools（保留全部工具，但过滤掉 web_search/websearch）
         let toolsContext = {};
@@ -1094,7 +1184,7 @@ async saveCredentialsToFile(filePath, newData) {
                         
                         return {
                             toolSpecification: {
-                                name: tool.name,
+                                name: toolNameMaps.toKiroName(tool.name),
                                 description: desc,
                                 inputSchema: {
                                     json: tool.input_schema || {}
@@ -1148,10 +1238,15 @@ async saveCredentialsToFile(filePath, newData) {
         const history = [];
         let startIndex = 0;
 
+        let prependSystemToCurrentMessage = false;
+
         // Handle system prompt
         if (systemPrompt) {
-            // If the first message is a user message, prepend system prompt to it
-            if (processedMessages[0].role === 'user') {
+            // Keep single-turn requests as a single current message. Duplicating the same user
+            // payload into history and currentMessage can make Kiro reject large agent prompts.
+            if (processedMessages[0].role === 'user' && processedMessages.length === 1) {
+                prependSystemToCurrentMessage = true;
+            } else if (processedMessages[0].role === 'user') {
                 let firstUserContent = this.getContentText(processedMessages[0]);
                 history.push({
                     userInputMessage: {
@@ -1267,7 +1362,7 @@ async saveCredentialsToFile(filePath, newData) {
                         } else if (part.type === 'tool_use') {
                             toolUses.push({
                                 input: this._sanitizeToolInput(part.input),
-                                name: part.name,
+                                name: toolNameMaps.toKiroName(part.name),
                                 toolUseId: part.id
                             });
                         }
@@ -1318,7 +1413,7 @@ async saveCredentialsToFile(filePath, newData) {
                     } else if (part.type === 'tool_use') {
                         assistantResponseMessage.toolUses.push({
                             input: this._sanitizeToolInput(part.input),
-                            name: part.name,
+                            name: toolNameMaps.toKiroName(part.name),
                             toolUseId: part.id
                         });
                     }
@@ -1368,7 +1463,7 @@ async saveCredentialsToFile(filePath, newData) {
                     } else if (part.type === 'tool_use') {
                         currentToolUses.push({
                             input: this._sanitizeToolInput(part.input),
-                            name: part.name,
+                            name: toolNameMaps.toKiroName(part.name),
                             toolUseId: part.id
                         });
                     } else if (part.type === 'image') {
@@ -1387,6 +1482,12 @@ async saveCredentialsToFile(filePath, newData) {
             // Kiro API 要求 content 不能为空，即使有 toolResults
             if (!currentContent) {
                 currentContent = currentToolResults.length > 0 ? 'Tool results provided.' : 'Continue';
+            }
+
+            if (prependSystemToCurrentMessage) {
+                currentContent = currentContent
+                    ? `${systemPrompt}\n\n${currentContent}`
+                    : systemPrompt;
             }
         }
 
@@ -1446,6 +1547,11 @@ async saveCredentialsToFile(filePath, newData) {
             request.profileArn = this.profileArn;
         }
 
+        Object.defineProperty(request, '_kiroToolNameMaps', {
+            value: toolNameMaps,
+            enumerable: false
+        });
+
         // 监控钩子：内部请求转换
         if (this.config?._monitorRequestId) {
             try {
@@ -1467,7 +1573,7 @@ async saveCredentialsToFile(filePath, newData) {
         return request;
     }
 
-    parseEventStreamChunk(rawData) {
+    parseEventStreamChunk(rawData, toolNameMaps = null) {
         const rawStr = Buffer.isBuffer(rawData) ? rawData.toString('utf8') : String(rawData);
         let fullContent = '';
         const toolCalls = [];
@@ -1507,7 +1613,7 @@ async saveCredentialsToFile(filePath, newData) {
                                 id: eventData.toolUseId,
                                 type: "function",
                                 function: {
-                                    name: eventData.name,
+                                    name: toolNameMaps?.fromKiroName ? toolNameMaps.fromKiroName(eventData.name) : eventData.name,
                                     arguments: ""
                                 }
                             };
@@ -1562,7 +1668,7 @@ async saveCredentialsToFile(filePath, newData) {
             fullContent = fullContent.replace(/\s+/g, ' ').trim();
         }
 
-        const uniqueToolCalls = deduplicateToolCalls(toolCalls);
+        const uniqueToolCalls = restoreKiroToolCallNames(deduplicateToolCalls(toolCalls), toolNameMaps);
         return { content: fullContent || '', toolCalls: uniqueToolCalls };
     }
  
@@ -1607,7 +1713,14 @@ async saveCredentialsToFile(filePath, newData) {
                 headers
             };
             this._applySidecar(axiosConfig);
-            const response = await this.axiosInstance.request(axiosConfig);
+            const releaseThrottle = await acquireKiroRequestSlot(this.config);
+            let response;
+            try {
+                response = await this.axiosInstance.request(axiosConfig);
+            } finally {
+                releaseThrottle();
+            }
+            response._kiroToolNameMaps = requestData._kiroToolNameMaps;
             return response;
         } catch (error) {
             const status = error.response?.status;
@@ -1892,6 +2005,7 @@ async saveCredentialsToFile(filePath, newData) {
     }
 
     _processApiResponse(response) {
+        const toolNameMaps = response?._kiroToolNameMaps;
         const rawResponseText = Buffer.isBuffer(response.data) ? response.data.toString('utf8') : String(response.data);
         //logger.info(`[Kiro] Raw response length: ${rawResponseText.length}`);
         if (rawResponseText.includes("[Called")) {
@@ -1899,7 +2013,7 @@ async saveCredentialsToFile(filePath, newData) {
         }
 
         // 1. Parse structured events and bracket calls from parsed content
-        const parsedFromEvents = this.parseEventStreamChunk(rawResponseText);
+        const parsedFromEvents = this.parseEventStreamChunk(rawResponseText, toolNameMaps);
         let fullResponseText = parsedFromEvents.content;
         let allToolCalls = [...parsedFromEvents.toolCalls]; // clone
         //logger.info(`[Kiro] Found ${allToolCalls.length} tool calls from event stream parsing.`);
@@ -1908,7 +2022,7 @@ async saveCredentialsToFile(filePath, newData) {
         const rawBracketToolCalls = parseBracketToolCalls(rawResponseText);
         if (rawBracketToolCalls) {
             //logger.info(`[Kiro] Found ${rawBracketToolCalls.length} bracket tool calls in raw response.`);
-            allToolCalls.push(...rawBracketToolCalls);
+            allToolCalls.push(...restoreKiroToolCallNames(rawBracketToolCalls, toolNameMaps));
         }
 
         // 3. Deduplicate all collected tool calls
@@ -2127,6 +2241,7 @@ async saveCredentialsToFile(filePath, newData) {
         }
 
         const requestData = await this.buildCodewhispererRequest(messages, model, body.tools, body.system, body.thinking);
+        const toolNameMaps = requestData._kiroToolNameMaps;
 
         const token = this.accessToken;
         const headers = {
@@ -2137,6 +2252,7 @@ async saveCredentialsToFile(filePath, newData) {
         const requestUrl = model.startsWith('amazonq') ? this.amazonQUrl : this.baseUrl;
 
         let stream = null;
+        let releaseThrottle = () => {};
         try {
             const axiosConfig = {
                 method: 'post',
@@ -2146,6 +2262,7 @@ async saveCredentialsToFile(filePath, newData) {
                 responseType: 'stream'
             };
             this._applySidecar(axiosConfig);
+            releaseThrottle = await acquireKiroRequestSlot(this.config);
             const response = await this.axiosInstance.request(axiosConfig);
 
             stream = response.data;
@@ -2170,7 +2287,11 @@ async saveCredentialsToFile(filePath, newData) {
                         lastContentEvent = event.data;
                         yield { type: 'content', content: event.data };
                     } else if (event.type === 'toolUse') {
-                        yield { type: 'toolUse', toolUse: event.data };
+                        const toolUse = {
+                            ...event.data,
+                            name: toolNameMaps?.fromKiroName ? toolNameMaps.fromKiroName(event.data?.name) : event.data?.name
+                        };
+                        yield { type: 'toolUse', toolUse };
                     } else if (event.type === 'toolUseInput') {
                         yield { type: 'toolUseInput', input: event.data.input };
                     } else if (event.type === 'toolUseStop') {
@@ -2259,6 +2380,7 @@ async saveCredentialsToFile(filePath, newData) {
             logger.error(`[Kiro] Stream API call failed (Status: ${status}, Code: ${errorCode}):`,  error.message);
             throw error;
         } finally {
+            releaseThrottle();
             // 确保流被关闭，释放资源
             if (stream && typeof stream.destroy === 'function') {
                 stream.destroy();
@@ -2318,6 +2440,8 @@ async saveCredentialsToFile(filePath, newData) {
             stoppedBlocks: new Set(),
             stripThinkingLeadingNewline: false,
             stripTextLeadingNewlinesAfterThinking: false,
+            hasVisibleText: false,
+            hasThinkingContent: false,
         };
 
         const ensureBlockStart = (blockType) => {
@@ -2353,6 +2477,9 @@ async saveCredentialsToFile(filePath, newData) {
 
         const createTextDeltaEvents = (text) => {
             if (!text) return [];
+            if (!isWhitespaceOnly(text)) {
+                streamState.hasVisibleText = true;
+            }
             const events = [];
             events.push(...ensureBlockStart('text'));
             events.push({
@@ -2364,6 +2491,9 @@ async saveCredentialsToFile(filePath, newData) {
         };
 
         const createThinkingDeltaEvents = (thinking) => {
+            if (thinking) {
+                streamState.hasThinkingContent = true;
+            }
             const events = [];
             events.push(...ensureBlockStart('thinking'));
             events.push({
@@ -2715,6 +2845,15 @@ async saveCredentialsToFile(filePath, newData) {
                 }
             }
 
+            const emittedOnlyThinking = thinkingRequested &&
+                streamState.hasThinkingContent &&
+                !streamState.hasVisibleText &&
+                toolCalls.length === 0;
+            if (emittedOnlyThinking) {
+                logger.warn('[Kiro Stream] Thinking-only response received; emitting minimal text block and max_tokens stop_reason');
+                yield* pushEvents(createTextDeltaEvents(' '));
+            }
+
             yield* pushEvents(stopBlock(streamState.textBlockIndex));
 
             // 检查文本内容中的 bracket 格式工具调用
@@ -2761,7 +2900,7 @@ async saveCredentialsToFile(filePath, newData) {
             // 4. 发送 message_delta 事件
             yield {
                 type: "message_delta",
-                delta: { stop_reason: toolCalls.length > 0 ? "tool_use" : "end_turn" },
+                delta: { stop_reason: toolCalls.length > 0 ? "tool_use" : (emittedOnlyThinking ? "max_tokens" : "end_turn") },
                 usage: {
                     input_tokens: inputTokens,
                     output_tokens: outputTokens,
@@ -2926,24 +3065,30 @@ async saveCredentialsToFile(filePath, newData) {
             let outputTokens = 0;
 
             // 1) Content blocks (text/thinking) first.
+            let hasTextContent = false;
+            let hasThinkingContent = false;
             if (Array.isArray(content)) {
                 for (const block of content) {
                     if (!block || typeof block !== 'object') continue;
                     if (block.type === 'text' && typeof block.text === 'string') {
                         contentArray.push({ type: 'text', text: block.text });
                         outputTokens += this.countTextTokens(block.text);
+                        if (!isWhitespaceOnly(block.text)) hasTextContent = true;
                     } else if (block.type === 'thinking' && typeof block.thinking === 'string') {
                         contentArray.push({ type: 'thinking', thinking: block.thinking });
                         outputTokens += this.countTextTokens(block.thinking);
+                        if (block.thinking) hasThinkingContent = true;
                     } else if (typeof block.text === 'string' && block.text) {
                         // Best-effort fallback for unknown blocks carrying plain text.
                         contentArray.push({ type: 'text', text: block.text });
                         outputTokens += this.countTextTokens(block.text);
+                        if (!isWhitespaceOnly(block.text)) hasTextContent = true;
                     }
                 }
             } else if (content) {
                 contentArray.push({ type: "text", text: content });
                 outputTokens += this.countTextTokens(content);
+                if (!isWhitespaceOnly(content)) hasTextContent = true;
             }
 
             // 2) Append tool_use blocks (if any).
@@ -2970,6 +3115,12 @@ async saveCredentialsToFile(filePath, newData) {
                     outputTokens += this.countTextTokens(tc.function.arguments);
                 }
                 stopReason = "tool_use"; // Set stop_reason to "tool_use" when toolCalls exist
+            }
+
+            if (hasThinkingContent && !hasTextContent && (!toolCalls || toolCalls.length === 0)) {
+                contentArray.push({ type: 'text', text: ' ' });
+                outputTokens += this.countTextTokens(' ');
+                stopReason = "max_tokens";
             }
 
             return {

--- a/tests/claude-kiro-request.test.js
+++ b/tests/claude-kiro-request.test.js
@@ -1,0 +1,191 @@
+import { execFileSync } from 'child_process';
+
+describe('Kiro CodeWhisperer request conversion', () => {
+    test('keeps single-turn user requests out of history', async () => {
+        execFileSync(process.execPath, ['--input-type=module', '-e', `
+            import { KiroApiService } from './src/providers/claude/claude-kiro.js';
+
+            const service = new KiroApiService();
+            const inputMessages = [
+                { role: 'user', content: 'hello' }
+            ];
+
+            const request = await service.buildCodewhispererRequest(
+                inputMessages,
+                'claude-opus-4-7',
+                null,
+                'system prompt'
+            );
+
+            if (request.conversationState.history !== undefined) {
+                throw new Error('single-turn request unexpectedly has history');
+            }
+
+            const content = request.conversationState.currentMessage.userInputMessage.content;
+            if (!content.includes('system prompt') || !content.includes('hello')) {
+                throw new Error('current message missing expected content');
+            }
+
+            if (JSON.stringify(inputMessages) !== JSON.stringify([{ role: 'user', content: 'hello' }])) {
+                throw new Error('input messages were mutated');
+            }
+
+            process.exit(0);
+        `], { cwd: process.cwd(), stdio: 'pipe' });
+    });
+
+    test('keeps prior turns in history for multi-turn requests', async () => {
+        execFileSync(process.execPath, ['--input-type=module', '-e', `
+            import { KiroApiService } from './src/providers/claude/claude-kiro.js';
+
+            const service = new KiroApiService();
+            const request = await service.buildCodewhispererRequest(
+                [
+                    { role: 'user', content: 'first' },
+                    { role: 'assistant', content: 'second' },
+                    { role: 'user', content: 'third' }
+                ],
+                'claude-opus-4-7',
+                null,
+                'system prompt'
+            );
+
+            const history = request.conversationState.history;
+            if (!Array.isArray(history) || history.length !== 2) {
+                throw new Error('multi-turn history length changed');
+            }
+
+            if (!history[0].userInputMessage?.content.includes('first')) {
+                throw new Error('first user turn missing from history');
+            }
+
+            if (history[1].assistantResponseMessage?.content !== 'second') {
+                throw new Error('assistant turn missing from history');
+            }
+
+            if (request.conversationState.currentMessage.userInputMessage.content !== 'third') {
+                throw new Error('current message changed');
+            }
+
+            process.exit(0);
+        `], { cwd: process.cwd(), stdio: 'pipe' });
+    });
+
+    test('shortens Kiro tool names and restores response tool calls', async () => {
+        execFileSync(process.execPath, ['--input-type=module', '-e', `
+            import { KiroApiService } from './src/providers/claude/claude-kiro.js';
+
+            const service = new KiroApiService();
+            const longToolName = 'mcp__claude_ai_Cloudflare_Developer_Platform__hyperdrive_config_delete';
+            const request = await service.buildCodewhispererRequest(
+                [
+                    { role: 'user', content: 'first' },
+                    {
+                        role: 'assistant',
+                        content: [
+                            { type: 'tool_use', id: 'toolu_1', name: longToolName, input: { hyperdrive_id: 'abc' } }
+                        ]
+                    },
+                    { role: 'user', content: 'continue' }
+                ],
+                'claude-opus-4-7',
+                [{
+                    name: longToolName,
+                    description: 'Delete a Hyperdrive configuration',
+                    input_schema: {
+                        type: 'object',
+                        additionalProperties: false,
+                        properties: { hyperdrive_id: { type: 'string' } },
+                        required: ['hyperdrive_id']
+                    }
+                }]
+            );
+
+            const toolSpec = request.conversationState.currentMessage.userInputMessage.userInputMessageContext.tools[0].toolSpecification;
+            if (toolSpec.name.length > 64 || toolSpec.name === longToolName) {
+                throw new Error('long tool name was not shortened for Kiro');
+            }
+
+            const assistantTool = request.conversationState.history[1].assistantResponseMessage.toolUses[0];
+            if (assistantTool.name !== toolSpec.name) {
+                throw new Error('assistant history tool_use was not mapped to the Kiro tool name');
+            }
+
+            const rawEvent = ':message-typeevent{"name":"' + toolSpec.name + '","toolUseId":"toolu_2","input":"{}","stop":true}';
+            const parsed = service.parseEventStreamChunk(rawEvent, request._kiroToolNameMaps);
+            if (parsed.toolCalls[0].function.name !== longToolName) {
+                throw new Error('Kiro tool name was not restored for Claude response');
+            }
+
+            process.exit(0);
+        `], { cwd: process.cwd(), stdio: 'pipe' });
+    });
+
+    test('marks thinking-only stream responses as max_tokens and emits a minimal text block', async () => {
+        execFileSync(process.execPath, ['--input-type=module', '-e', `
+            import { KiroApiService } from './src/providers/claude/claude-kiro.js';
+
+            class TestKiroApiService extends KiroApiService {
+                constructor() {
+                    super();
+                    this.isInitialized = true;
+                }
+
+                async *streamApiReal() {
+                    yield { type: 'content', content: '<thinking>spent the whole budget</thinking>' };
+                    yield { type: 'contextUsage', contextUsagePercentage: 1 };
+                }
+            }
+
+            const service = new TestKiroApiService();
+            const events = [];
+            for await (const event of service.generateContentStream('claude-opus-4-7', {
+                thinking: { type: 'enabled', budget_tokens: 1024 },
+                messages: [{ role: 'user', content: 'hello' }]
+            })) {
+                events.push(event);
+            }
+
+            const textDelta = events.find(event =>
+                event.type === 'content_block_delta' &&
+                event.delta?.type === 'text_delta' &&
+                event.delta?.text === ' '
+            );
+            if (!textDelta) {
+                throw new Error('thinking-only stream did not emit the minimal text block');
+            }
+
+            const messageDelta = events.find(event => event.type === 'message_delta');
+            if (messageDelta?.delta?.stop_reason !== 'max_tokens') {
+                throw new Error('thinking-only stream did not use max_tokens stop_reason');
+            }
+
+            process.exit(0);
+        `], { cwd: process.cwd(), stdio: 'pipe' });
+    });
+
+    test('marks thinking-only non-stream responses as max_tokens', async () => {
+        execFileSync(process.execPath, ['--input-type=module', '-e', `
+            import { KiroApiService } from './src/providers/claude/claude-kiro.js';
+
+            const service = new KiroApiService();
+            const response = service.buildClaudeResponse(
+                [{ type: 'thinking', thinking: 'spent the whole budget' }],
+                false,
+                'assistant',
+                'claude-opus-4-7',
+                null,
+                10
+            );
+
+            if (response.stop_reason !== 'max_tokens') {
+                throw new Error('thinking-only non-stream response did not use max_tokens stop_reason');
+            }
+            if (!response.content.some(block => block.type === 'text' && block.text === ' ')) {
+                throw new Error('thinking-only non-stream response did not include a minimal text block');
+            }
+
+            process.exit(0);
+        `], { cwd: process.cwd(), stdio: 'pipe' });
+    });
+});


### PR DESCRIPTION
## Summary

This PR tightens the Kiro request/response compatibility path for agent clients that send large single-turn prompts, long MCP tool names, and extended-thinking responses.

Changes included:

- keep single-turn Kiro requests as a single `currentMessage` instead of duplicating the same user payload into both `history` and `currentMessage`
- shorten Kiro tool names longer than 64 characters with stable SHA-based aliases before sending them upstream
- map aliased tool names in outgoing tool definitions, assistant history, and current tool-use blocks, then restore the original tool names in Claude-compatible responses
- handle thinking-only Kiro responses by emitting a minimal text block and reporting `stop_reason: "max_tokens"` instead of returning an empty assistant message
- add an optional local request throttle via `KIRO_REQUEST_MIN_INTERVAL_MS` for deployments that need to avoid bursts against a single Kiro account
- add focused regression coverage for the request conversion, tool aliasing, and thinking-only response behavior

## Context

There are several existing reports showing that Kiro compatibility failures are often request-shape dependent rather than simple credential failures:

- #395 reports recent Kiro reverse-proxy failures around Sonnet/Opus, including 400/429 behavior and a maintainer note that request-format compatibility still needs work.
- #522 reports `claude-kiro-oauth` returning 400 after recent versions; the discussion includes client-specific payloads where one client succeeds and another produces an upstream `Improperly formed request`.
- #311 and #89 are older examples of Kiro 400 `Improperly formed request` failures caused by request payload details, especially around tool conversion.
- #122 confirms that some clients' built-in tool formats are not directly supported by Kiro, so the proxy needs to be careful about the exact upstream tool schema it emits.
- #223 previously fixed another Kiro tool compatibility edge case, which is the same broad class of problem as this PR's tool-name aliasing.
- #320 added extended-thinking support; this PR only fixes the edge case where Kiro emits thinking content but no visible text/tool call, which otherwise becomes an empty assistant response for Claude-compatible clients.

## Notes

This PR intentionally does not change the built-in Kiro identity/system prompt behavior. That is mentioned in #395, but it is a separate behavioral change and should be reviewed independently.

The throttle is opt-in. Existing deployments keep the current behavior unless `KIRO_REQUEST_MIN_INTERVAL_MS` is configured.

## Testing

- `npm test -- --runTestsByPath tests/claude-kiro-request.test.js`
