### PR TITLE
fix(codex): improve Responses API compatibility

### DIFF
--- a/docs/CODEX_RESPONSES_BYOK_ROLLBACK_2026-05-13.md
+++ b/docs/CODEX_RESPONSES_BYOK_ROLLBACK_2026-05-13.md
@@ -1,0 +1,66 @@
+# Codex Responses BYOK rollback note — 2026-05-13
+
+This note covers the local branch `draft-codex-responses-compat-guards` after commit `2f0d5d0` (`fix: default Codex Responses canonical stream`).
+
+## Scope
+
+The change is source-only in this repository/fork. It was pushed to the fork branch and therefore updates the existing upstream PR for Codex Responses compatibility. It was not deployed to the live API panel/container by this commit.
+
+Changed areas:
+
+- `src/utils/common.js`
+  - default `CODEX_RESPONSES_STREAM_MODE` changed from `raw` to `canonical`;
+  - OpenAI Responses system prompt extraction added.
+- `src/providers/openai/openai-responses-strategy.js`
+  - fixes previously undefined `existingSystemText` in Responses system-prompt injection.
+- `src/converters/strategies/OpenAIResponsesConverter.js`
+  - normalizes direct Responses `tool_choice: { type: "function", name }` for OpenAI Chat and Claude conversion.
+- Tests:
+  - `tests/codex-responses-compat.test.js`
+  - `tests/openai-responses-compat.test.js`
+
+## Runtime rollback without reverting code
+
+If the code is deployed and canonical mode causes regressions, restore the old stream behavior by explicitly setting:
+
+```text
+CODEX_RESPONSES_STREAM_MODE=raw
+```
+
+Then restart the AIClient2API process/container so the environment is reloaded.
+
+## Git rollback
+
+From this repository:
+
+```powershell
+Set-Location 'I:\Git\Upstream\AIClient2API'
+```
+
+Revert only the 2026-05-13 default-canonical patch:
+
+```powershell
+git revert 2f0d5d0
+```
+
+If this rollback note itself should also be reverted after it is committed, revert the rollback-note commit too.
+
+## Local uncommitted rollback, if needed before committing
+
+If the same changes are present only as local edits, restore modified tracked files and remove the added test:
+
+```powershell
+git restore src/converters/strategies/OpenAIResponsesConverter.js src/providers/openai/openai-responses-strategy.js src/utils/common.js tests/codex-responses-compat.test.js
+Remove-Item 'tests/openai-responses-compat.test.js'
+```
+
+## Validation commands
+
+Focused/non-integration validation used for this patch:
+
+```powershell
+npm test -- --runTestsByPath tests/codex-responses-compat.test.js tests/openai-responses-compat.test.js
+npm test -- --testPathIgnorePatterns=api-integration.test.js
+```
+
+The full `npm test` includes `tests/api-integration.test.js`, which targets the upstream owner's hardcoded integration server `http://192.168.1.232:3000`; that address is not the local/live panel used in our environment.

--- a/src/converters/strategies/CodexConverter.js
+++ b/src/converters/strategies/CodexConverter.js
@@ -5,12 +5,13 @@
 
 import { v4 as uuidv4 } from 'uuid';
 import { BaseConverter } from '../BaseConverter.js';
-import { MODEL_PROTOCOL_PREFIX } from '../../utils/common.js';
+import { MODEL_PROTOCOL_PREFIX, getCodexResponsesStreamMode } from '../../utils/common.js';
 import {
     generateResponseCreated,
     generateResponseInProgress,
     generateOutputItemAdded,
     generateContentPartAdded,
+    generateOutputTextDelta,
     generateOutputTextDone,
     generateContentPartDone,
     generateOutputItemDone,
@@ -130,7 +131,7 @@ export class CodexConverter extends BaseConverter {
             case MODEL_PROTOCOL_PREFIX.OPENAI:
                 return this.toOpenAIStreamChunk(chunk, model);
             case MODEL_PROTOCOL_PREFIX.OPENAI_RESPONSES:
-                return this.toOpenAIResponsesStreamChunk(chunk, model);
+                return this.toOpenAIResponsesStreamChunk(chunk, model, requestId);
             case MODEL_PROTOCOL_PREFIX.GEMINI:
                 return this.toGeminiStreamChunk(chunk, model, requestId);
             case MODEL_PROTOCOL_PREFIX.CLAUDE:
@@ -1208,13 +1209,13 @@ export class CodexConverter extends BaseConverter {
     /**
      * Codex → OpenAI Responses 流式响应转换
      */
-    toOpenAIResponsesStreamChunk(chunk, model) {
-        if(true){
+    toOpenAIResponsesStreamChunk(chunk, model, requestId) {
+        if (getCodexResponsesStreamMode() !== 'canonical') {
             return chunk;
         }
 
         const type = chunk.type;
-        const resId = chunk.response?.id || 'default';
+        const resId = requestId || chunk.response?.id || chunk.response_id || 'default';
         
         if (!this.streamParams.has(resId)) {
             this.streamParams.set(resId, {
@@ -1222,7 +1223,11 @@ export class CodexConverter extends BaseConverter {
                 createdAt: Math.floor(Date.now() / 1000),
                 responseID: resId,
                 functionCallIndex: -1,
-                eventsSent: new Set()
+                eventsSent: new Set(),
+                outputText: '',
+                hasText: false,
+                messageItemId: null,
+                functionCalls: []
             });
         }
         const state = this.streamParams.get(resId);
@@ -1249,57 +1254,166 @@ export class CodexConverter extends BaseConverter {
 
         if (type === 'response.output_text.delta') {
             if (!state.eventsSent.has('output_item_added')) {
-                events.push(generateOutputItemAdded(state.responseID));
+                const added = generateOutputItemAdded(state.responseID);
+                state.messageItemId = added.item?.id || state.messageItemId;
+                events.push(added);
                 state.eventsSent.add('output_item_added');
             }
             if (!state.eventsSent.has('content_part_added')) {
                 events.push(generateContentPartAdded(state.responseID));
                 state.eventsSent.add('content_part_added');
             }
+            const delta = typeof chunk.delta === 'string' ? chunk.delta : '';
+            state.outputText += delta;
+            state.hasText = true;
+            events.push(generateOutputTextDelta(state.responseID, delta));
+            return events;
+        }
+
+        if (type === 'response.output_text.done') {
+            if (typeof chunk.text === 'string') {
+                state.outputText = chunk.text;
+                state.hasText = true;
+            }
+            return null;
+        }
+
+        if (type === 'response.output_item.added' && chunk.item?.type === 'function_call') {
+            const itemId = chunk.item.id || chunk.item.call_id || `fc_${uuidv4().replace(/-/g, '')}`;
+            const callId = chunk.item.call_id || itemId;
+            const call = {
+                id: itemId,
+                call_id: callId,
+                type: 'function_call',
+                name: this.getOriginalToolName(chunk.item.name),
+                arguments: '{}',
+                status: 'in_progress',
+                output_index: chunk.output_index ?? state.functionCalls.length,
+                hasArgsDelta: false
+            };
+            state.functionCalls.push(call);
             events.push({
-                type: "response.output_text.delta",
+                type: 'response.output_item.added',
                 response_id: state.responseID,
-                delta: chunk.delta
+                output_index: call.output_index,
+                item: { ...call, arguments: '' }
+            });
+            return events;
+        }
+
+        if (type === 'response.function_call_arguments.delta') {
+            const delta = typeof chunk.delta === 'string' ? chunk.delta : '';
+            const call = state.functionCalls.find(c => c.id === chunk.item_id || c.call_id === chunk.item_id);
+            if (!call) return null;
+            call.arguments = call.arguments && call.arguments !== '{}' ? call.arguments + delta : delta;
+            call.hasArgsDelta = true;
+            events.push({
+                type: 'response.function_call_arguments.delta',
+                response_id: state.responseID,
+                item_id: call.id,
+                output_index: call.output_index,
+                delta
             });
             return events;
         }
 
         if (type === 'response.output_item.done' && chunk.item?.type === 'function_call') {
-            events.push({
-                type: "response.output_item.added",
-                response_id: state.responseID,
-                item: {
-                    id: chunk.item.call_id,
-                    type: "function_call",
+            const itemId = chunk.item.id || chunk.item.call_id || `fc_${uuidv4().replace(/-/g, '')}`;
+            const callId = chunk.item.call_id || itemId;
+            let args = chunk.item.arguments;
+            if (args === undefined || args === null) args = '{}';
+            if (typeof args !== 'string') args = JSON.stringify(args);
+            let call = state.functionCalls.find(c => c.id === itemId || c.call_id === callId);
+            if (!call) {
+                call = {
+                    id: itemId,
+                    call_id: callId,
+                    type: 'function_call',
                     name: this.getOriginalToolName(chunk.item.name),
-                    arguments: typeof chunk.item.arguments === 'string' ? chunk.item.arguments : JSON.stringify(chunk.item.arguments),
-                    status: "completed"
-                }
+                    arguments: args,
+                    status: 'in_progress',
+                    output_index: chunk.output_index ?? state.functionCalls.length,
+                    hasArgsDelta: false
+                };
+                state.functionCalls.push(call);
+                events.push({
+                    type: 'response.output_item.added',
+                    response_id: state.responseID,
+                    output_index: call.output_index,
+                    item: { ...call, arguments: '' }
+                });
+            }
+            call.name = this.getOriginalToolName(chunk.item.name);
+            call.arguments = args;
+            call.status = 'completed';
+            if (!call.hasArgsDelta) {
+                events.push({
+                    type: 'response.function_call_arguments.delta',
+                    response_id: state.responseID,
+                    item_id: call.id,
+                    output_index: call.output_index,
+                    delta: args
+                });
+                call.hasArgsDelta = true;
+            }
+            events.push({
+                type: 'response.function_call_arguments.done',
+                response_id: state.responseID,
+                item_id: call.id,
+                output_index: call.output_index,
+                arguments: args
             });
             events.push({
-                type: "response.output_item.done",
+                type: 'response.output_item.done',
                 response_id: state.responseID,
-                item_id: chunk.item.call_id
+                output_index: call.output_index,
+                item: {
+                    id: call.id,
+                    call_id: call.call_id,
+                    type: 'function_call',
+                    name: call.name,
+                    arguments: call.arguments,
+                    status: 'completed'
+                }
             });
             return events;
         }
 
         if (type === 'response.completed') {
-            events.push(
-                generateOutputTextDone(state.responseID),
-                generateContentPartDone(state.responseID),
-                generateOutputItemDone(state.responseID)
-            );
+            if (state.hasText && !state.eventsSent.has('text_done')) {
+                events.push(
+                    generateOutputTextDone(state.responseID),
+                    generateContentPartDone(state.responseID),
+                    generateOutputItemDone(state.responseID)
+                );
+                state.eventsSent.add('text_done');
+            }
             const completedEvent = generateResponseCompleted(state.responseID);
+            const output = [];
+            if (state.hasText) {
+                output.push(...(completedEvent.response.output || []).filter(item => item.type === 'message'));
+            }
+            output.push(...state.functionCalls.map(call => ({
+                id: call.id,
+                call_id: call.call_id,
+                type: 'function_call',
+                name: call.name,
+                arguments: call.arguments || '{}',
+                status: 'completed'
+            })));
+            if (output.length > 0) {
+                completedEvent.response.output = output;
+            }
+            completedEvent.response.status = 'completed';
             completedEvent.response.usage = {
-                input_tokens: chunk.response.usage?.input_tokens || 0,
-                output_tokens: chunk.response.usage?.output_tokens || 0,
-                total_tokens: chunk.response.usage?.total_tokens || 0,
+                input_tokens: chunk.response?.usage?.input_tokens || 0,
+                output_tokens: chunk.response?.usage?.output_tokens || 0,
+                total_tokens: chunk.response?.usage?.total_tokens || 0,
                 input_tokens_details: {
-                    cached_tokens: this.getCachedInputTokens(chunk.response.usage)
+                    cached_tokens: this.getCachedInputTokens(chunk.response?.usage)
                 },
                 output_tokens_details: {
-                    reasoning_tokens: chunk.response.usage?.output_tokens_details?.reasoning_tokens || 0
+                    reasoning_tokens: chunk.response?.usage?.output_tokens_details?.reasoning_tokens || 0
                 }
             };
             events.push(completedEvent);

--- a/src/converters/strategies/CodexConverter.js
+++ b/src/converters/strategies/CodexConverter.js
@@ -201,6 +201,21 @@ export class CodexConverter extends BaseConverter {
         delete codexRequest.temperature;
         delete codexRequest.top_p;
         delete codexRequest.user;
+        delete codexRequest.prompt_cache_retention;
+        delete codexRequest.safety_identifier;
+
+        if (Array.isArray(codexRequest.tools)) {
+            this.buildToolNameMap(codexRequest.tools);
+            codexRequest.tools = this.convertTools(codexRequest.tools);
+        }
+
+        if (codexRequest.tool_choice) {
+            codexRequest.tool_choice = this.convertToolChoice(codexRequest.tool_choice);
+        }
+
+        if (!codexRequest.instructions || !String(codexRequest.instructions).trim()) {
+            codexRequest.instructions = 'You are a helpful coding assistant.';
+        }
         
         // 添加 reasoning 配置
         codexRequest.reasoning = {
@@ -593,7 +608,7 @@ export class CodexConverter extends BaseConverter {
         }
 
         if (toolChoice.type === 'function') {
-            const name = toolChoice.function?.name;
+            const name = toolChoice.function?.name || toolChoice.name;
             const shortName = name ? (this.toolNameMap.get(name) || this.shortenToolName(name)) : '';
             return {
                 type: 'function',

--- a/src/converters/strategies/CodexConverter.js
+++ b/src/converters/strategies/CodexConverter.js
@@ -211,9 +211,7 @@ export class CodexConverter extends BaseConverter {
             codexRequest.tool_choice = this.convertToolChoice(codexRequest.tool_choice);
         }
 
-        if (!codexRequest.instructions || !String(codexRequest.instructions).trim()) {
-            codexRequest.instructions = 'You are a helpful coding assistant.';
-        }
+        const hasExplicitInstructions = !!(codexRequest.instructions && String(codexRequest.instructions).trim());
         
         // 添加 reasoning 配置
         codexRequest.reasoning = {
@@ -225,8 +223,8 @@ export class CodexConverter extends BaseConverter {
         // 确保 input 数组中的每个项都有 type: "message"，并将系统角色转换为开发者角色
         if (codexRequest.input && Array.isArray(codexRequest.input)) {
             codexRequest.input = codexRequest.input.filter(item => {
-                // 如果 instructions 已存在，过滤掉 input 中的 system/developer 消息以避免重复
-                if (codexRequest.instructions && (item.role === 'system' || item.role === 'developer')) {
+                // 如果显式 instructions 已存在，过滤掉 input 中的 system/developer 消息以避免重复
+                if (hasExplicitInstructions && (item.role === 'system' || item.role === 'developer')) {
                     return false;
                 }
                 return true;
@@ -244,6 +242,10 @@ export class CodexConverter extends BaseConverter {
                 return item;
             });
         }
+        if (!hasExplicitInstructions && (!codexRequest.instructions || !String(codexRequest.instructions).trim())) {
+            codexRequest.instructions = 'You are a helpful coding assistant.';
+        }
+
         // 确保 text.format 是对象而非字符串
         if (codexRequest.text?.format && typeof codexRequest.text.format === 'string') {
             const fmt = codexRequest.text.format;
@@ -1228,7 +1230,8 @@ export class CodexConverter extends BaseConverter {
                 messageItemId: null,
                 messageOutputIndex: null,
                 nextOutputIndex: 0,
-                functionCalls: []
+                functionCalls: [],
+                imageGenerationCalls: []
             });
         }
         const state = this.streamParams.get(resId);
@@ -1352,17 +1355,37 @@ export class CodexConverter extends BaseConverter {
 
         if (type === 'response.output_text.done') {
             setOutputText(chunk.text);
-            return null;
+            if (state.hasText) events.push(...ensureTextLifecycleStarted());
+            return events.length > 0 ? events : null;
         }
 
         if (type === 'response.content_part.done' && chunk.part?.type === 'output_text') {
             setOutputText(chunk.part.text);
-            return null;
+            if (state.hasText) events.push(...ensureTextLifecycleStarted());
+            return events.length > 0 ? events : null;
         }
 
         if (type === 'response.output_item.done' && chunk.item?.type === 'message') {
             setOutputText(extractMessageText(chunk.item));
-            return null;
+            if (state.hasText) events.push(...ensureTextLifecycleStarted());
+            return events.length > 0 ? events : null;
+        }
+
+        if (type === 'response.output_item.done' && chunk.item?.type === 'image_generation_call') {
+            const outputIndex = state.nextOutputIndex++;
+            state.imageGenerationCalls.push({ ...chunk.item, output_index: outputIndex });
+            events.push({
+                type: 'response.output_item.added',
+                response_id: state.responseID,
+                output_index: outputIndex,
+                item: { ...chunk.item, status: chunk.item.status || 'in_progress' }
+            }, {
+                type: 'response.output_item.done',
+                response_id: state.responseID,
+                output_index: outputIndex,
+                item: { ...chunk.item, status: chunk.item.status || 'completed' }
+            });
+            return events;
         }
 
         if (type === 'response.output_item.added' && chunk.item?.type === 'function_call') {
@@ -1467,7 +1490,13 @@ export class CodexConverter extends BaseConverter {
         }
 
         if (type === 'response.completed') {
+            const completedOutput = Array.isArray(chunk.response?.output) ? chunk.response.output : [];
             setOutputText(extractCompletedMessageText(chunk.response));
+            for (const item of completedOutput) {
+                if (item?.type === 'image_generation_call' && !state.imageGenerationCalls.some(existing => existing.id && existing.id === item.id)) {
+                    state.imageGenerationCalls.push({ ...item, output_index: state.nextOutputIndex++ });
+                }
+            }
             if (state.hasText && !state.eventsSent.has('text_done')) {
                 events.push(
                     ...ensureTextLifecycleStarted(),
@@ -1476,18 +1505,31 @@ export class CodexConverter extends BaseConverter {
                 state.eventsSent.add('text_done');
             }
             const completedEvent = generateResponseCompleted(state.responseID);
-            const output = [];
+            const outputItems = [];
             if (state.hasText) {
-                output.push(buildTextOutputItem());
+                outputItems.push({ output_index: getMessageOutputIndex(), item: buildTextOutputItem() });
             }
-            output.push(...state.functionCalls.map(call => ({
-                id: call.id,
-                call_id: call.call_id,
-                type: 'function_call',
-                name: call.name,
-                arguments: call.arguments || '{}',
-                status: 'completed'
+            outputItems.push(...state.functionCalls.map(call => ({
+                output_index: call.output_index,
+                item: {
+                    id: call.id,
+                    call_id: call.call_id,
+                    type: 'function_call',
+                    name: call.name,
+                    arguments: call.arguments || '{}',
+                    status: 'completed'
+                }
             })));
+            outputItems.push(...state.imageGenerationCalls.map(call => {
+                const { output_index, ...item } = call;
+                return {
+                    output_index,
+                    item: { ...item, status: item.status || 'completed' }
+                };
+            }));
+            const output = outputItems
+                .sort((a, b) => a.output_index - b.output_index)
+                .map(entry => entry.item);
             if (output.length > 0) {
                 completedEvent.response.output = output;
             }

--- a/src/converters/strategies/CodexConverter.js
+++ b/src/converters/strategies/CodexConverter.js
@@ -12,9 +12,6 @@ import {
     generateOutputItemAdded,
     generateContentPartAdded,
     generateOutputTextDelta,
-    generateOutputTextDone,
-    generateContentPartDone,
-    generateOutputItemDone,
     generateResponseCompleted
 } from '../../providers/openai/openai-responses-core.mjs';
 
@@ -1262,6 +1259,68 @@ export class CodexConverter extends BaseConverter {
             }
             return textEvents;
         };
+        const extractMessageText = (item) => {
+            if (!item || item.type !== 'message') return '';
+            if (typeof item.content === 'string') return item.content;
+            if (!Array.isArray(item.content)) return '';
+            return item.content.map(part => {
+                if (typeof part === 'string') return part;
+                if ((part?.type === 'output_text' || part?.type === 'text') && typeof part.text === 'string') {
+                    return part.text;
+                }
+                return '';
+            }).join('');
+        };
+        const extractCompletedMessageText = (response) => {
+            const output = Array.isArray(response?.output) ? response.output : [];
+            return output.map(extractMessageText).filter(Boolean).join('');
+        };
+        const setOutputText = (text) => {
+            if (typeof text !== 'string' || text.length === 0) return;
+            state.outputText = text;
+            state.hasText = true;
+        };
+        const buildTextOutputItem = () => ({
+            id: state.messageItemId,
+            summary: [],
+            type: 'message',
+            role: 'assistant',
+            status: 'completed',
+            content: [{
+                type: 'output_text',
+                text: state.outputText,
+                annotations: [],
+                logprobs: []
+            }]
+        });
+        const buildTextDoneEvents = () => {
+            const outputIndex = getMessageOutputIndex();
+            const itemId = state.messageItemId;
+            const outputItem = buildTextOutputItem();
+            return [{
+                type: 'response.output_text.done',
+                item_id: itemId,
+                output_index: outputIndex,
+                content_index: 0,
+                text: state.outputText,
+                logprobs: []
+            }, {
+                type: 'response.content_part.done',
+                item_id: itemId,
+                output_index: outputIndex,
+                content_index: 0,
+                part: {
+                    type: 'output_text',
+                    text: state.outputText,
+                    annotations: [],
+                    logprobs: []
+                }
+            }, {
+                type: 'response.output_item.done',
+                output_index: outputIndex,
+                item: outputItem
+            }];
+        };
 
         if (type === 'response.created') {
             state.responseID = chunk.response.id;
@@ -1286,16 +1345,23 @@ export class CodexConverter extends BaseConverter {
             events.push(...ensureTextLifecycleStarted());
             const delta = typeof chunk.delta === 'string' ? chunk.delta : '';
             state.outputText += delta;
-            state.hasText = true;
+            if (delta.length > 0) state.hasText = true;
             events.push(patchTextOutputIndex(generateOutputTextDelta(state.responseID, delta)));
             return events;
         }
 
         if (type === 'response.output_text.done') {
-            if (typeof chunk.text === 'string') {
-                state.outputText = chunk.text;
-                state.hasText = true;
-            }
+            setOutputText(chunk.text);
+            return null;
+        }
+
+        if (type === 'response.content_part.done' && chunk.part?.type === 'output_text') {
+            setOutputText(chunk.part.text);
+            return null;
+        }
+
+        if (type === 'response.output_item.done' && chunk.item?.type === 'message') {
+            setOutputText(extractMessageText(chunk.item));
             return null;
         }
 
@@ -1401,19 +1467,18 @@ export class CodexConverter extends BaseConverter {
         }
 
         if (type === 'response.completed') {
+            setOutputText(extractCompletedMessageText(chunk.response));
             if (state.hasText && !state.eventsSent.has('text_done')) {
                 events.push(
                     ...ensureTextLifecycleStarted(),
-                    patchTextOutputIndex(generateOutputTextDone(state.responseID)),
-                    patchTextOutputIndex(generateContentPartDone(state.responseID)),
-                    patchTextOutputIndex(generateOutputItemDone(state.responseID))
+                    ...buildTextDoneEvents()
                 );
                 state.eventsSent.add('text_done');
             }
             const completedEvent = generateResponseCompleted(state.responseID);
             const output = [];
             if (state.hasText) {
-                output.push(...(completedEvent.response.output || []).filter(item => item.type === 'message'));
+                output.push(buildTextOutputItem());
             }
             output.push(...state.functionCalls.map(call => ({
                 id: call.id,

--- a/src/converters/strategies/CodexConverter.js
+++ b/src/converters/strategies/CodexConverter.js
@@ -210,6 +210,7 @@ export class CodexConverter extends BaseConverter {
         if (codexRequest.tool_choice) {
             codexRequest.tool_choice = this.convertToolChoice(codexRequest.tool_choice);
         }
+        // codexResponsesToolChoiceCompat
 
         const hasExplicitInstructions = !!(codexRequest.instructions && String(codexRequest.instructions).trim());
         

--- a/src/converters/strategies/CodexConverter.js
+++ b/src/converters/strategies/CodexConverter.js
@@ -1229,11 +1229,39 @@ export class CodexConverter extends BaseConverter {
                 outputText: '',
                 hasText: false,
                 messageItemId: null,
+                messageOutputIndex: null,
+                nextOutputIndex: 0,
                 functionCalls: []
             });
         }
         const state = this.streamParams.get(resId);
         const events = [];
+        const getMessageOutputIndex = () => {
+            if (state.messageOutputIndex === null || state.messageOutputIndex === undefined) {
+                state.messageOutputIndex = state.nextOutputIndex++;
+            }
+            return state.messageOutputIndex;
+        };
+        const patchTextOutputIndex = (event) => {
+            if (event && typeof event === 'object') {
+                event.output_index = getMessageOutputIndex();
+            }
+            return event;
+        };
+        const ensureTextLifecycleStarted = () => {
+            const textEvents = [];
+            if (!state.eventsSent.has('output_item_added')) {
+                const added = patchTextOutputIndex(generateOutputItemAdded(state.responseID));
+                state.messageItemId = added.item?.id || state.messageItemId;
+                textEvents.push(added);
+                state.eventsSent.add('output_item_added');
+            }
+            if (!state.eventsSent.has('content_part_added')) {
+                textEvents.push(patchTextOutputIndex(generateContentPartAdded(state.responseID)));
+                state.eventsSent.add('content_part_added');
+            }
+            return textEvents;
+        };
 
         if (type === 'response.created') {
             state.responseID = chunk.response.id;
@@ -1255,20 +1283,11 @@ export class CodexConverter extends BaseConverter {
         }
 
         if (type === 'response.output_text.delta') {
-            if (!state.eventsSent.has('output_item_added')) {
-                const added = generateOutputItemAdded(state.responseID);
-                state.messageItemId = added.item?.id || state.messageItemId;
-                events.push(added);
-                state.eventsSent.add('output_item_added');
-            }
-            if (!state.eventsSent.has('content_part_added')) {
-                events.push(generateContentPartAdded(state.responseID));
-                state.eventsSent.add('content_part_added');
-            }
+            events.push(...ensureTextLifecycleStarted());
             const delta = typeof chunk.delta === 'string' ? chunk.delta : '';
             state.outputText += delta;
             state.hasText = true;
-            events.push(generateOutputTextDelta(state.responseID, delta));
+            events.push(patchTextOutputIndex(generateOutputTextDelta(state.responseID, delta)));
             return events;
         }
 
@@ -1290,7 +1309,7 @@ export class CodexConverter extends BaseConverter {
                 name: this.getOriginalToolName(chunk.item.name),
                 arguments: '{}',
                 status: 'in_progress',
-                output_index: chunk.output_index ?? state.functionCalls.length,
+                output_index: state.nextOutputIndex++,
                 hasArgsDelta: false
             };
             state.functionCalls.push(call);
@@ -1334,7 +1353,7 @@ export class CodexConverter extends BaseConverter {
                     name: this.getOriginalToolName(chunk.item.name),
                     arguments: args,
                     status: 'in_progress',
-                    output_index: chunk.output_index ?? state.functionCalls.length,
+                    output_index: state.nextOutputIndex++,
                     hasArgsDelta: false
                 };
                 state.functionCalls.push(call);
@@ -1384,9 +1403,10 @@ export class CodexConverter extends BaseConverter {
         if (type === 'response.completed') {
             if (state.hasText && !state.eventsSent.has('text_done')) {
                 events.push(
-                    generateOutputTextDone(state.responseID),
-                    generateContentPartDone(state.responseID),
-                    generateOutputItemDone(state.responseID)
+                    ...ensureTextLifecycleStarted(),
+                    patchTextOutputIndex(generateOutputTextDone(state.responseID)),
+                    patchTextOutputIndex(generateContentPartDone(state.responseID)),
+                    patchTextOutputIndex(generateOutputItemDone(state.responseID))
                 );
                 state.eventsSent.add('text_done');
             }

--- a/src/converters/strategies/CodexConverter.js
+++ b/src/converters/strategies/CodexConverter.js
@@ -819,8 +819,10 @@ export class CodexConverter extends BaseConverter {
                         });
                     }
                 } else if (item.type === 'function_call') {
+                    const callId = item.call_id || item.id || `call_${uuidv4().replace(/-/g, '')}`;
                     output.push({
-                        id: item.call_id || `call_${uuidv4().replace(/-/g, '')}`,
+                        id: item.id || callId,
+                        call_id: callId,
                         type: "function_call",
                         name: this.getOriginalToolName(item.name),
                         arguments: typeof item.arguments === 'string' ? item.arguments : JSON.stringify(item.arguments),

--- a/src/converters/strategies/OpenAIResponsesConverter.js
+++ b/src/converters/strategies/OpenAIResponsesConverter.js
@@ -115,6 +115,41 @@ export class OpenAIResponsesConverter extends BaseConverter {
     // 转换到 OpenAI 格式
     // =============================================================================
 
+    normalizeOpenAIToolChoice(toolChoice) {
+        if (!toolChoice || typeof toolChoice !== 'object') {
+            return toolChoice;
+        }
+        if (toolChoice.type === 'function') {
+            const name = toolChoice.function?.name || toolChoice.name;
+            if (name) {
+                return { type: 'function', function: { name } };
+            }
+        }
+        return toolChoice;
+    }
+
+    normalizeClaudeToolChoice(toolChoice) {
+        if (!toolChoice) {
+            return undefined;
+        }
+        if (typeof toolChoice === 'string') {
+            if (toolChoice === 'auto') {
+                return { type: 'auto' };
+            }
+            if (toolChoice === 'required') {
+                return { type: 'any' };
+            }
+            return undefined;
+        }
+        if (toolChoice.type === 'function') {
+            const name = toolChoice.function?.name || toolChoice.name;
+            if (name) {
+                return { type: 'tool', name };
+            }
+        }
+        return undefined;
+    }
+
     /**
      * 将 OpenAI Responses 请求转换为标准 OpenAI 请求
      */
@@ -242,7 +277,7 @@ export class OpenAIResponsesConverter extends BaseConverter {
         }
 
         if (responsesRequest.tool_choice) {
-            openaiRequest.tool_choice = responsesRequest.tool_choice;
+            openaiRequest.tool_choice = this.normalizeOpenAIToolChoice(responsesRequest.tool_choice);
         }
 
         return openaiRequest;
@@ -482,19 +517,9 @@ export class OpenAIResponsesConverter extends BaseConverter {
             }));
         }
 
-        if (responsesRequest.tool_choice) {
-            if (typeof responsesRequest.tool_choice === 'string') {
-                if (responsesRequest.tool_choice === 'auto') {
-                    claudeRequest.tool_choice = { type: 'auto' };
-                } else if (responsesRequest.tool_choice === 'required') {
-                    claudeRequest.tool_choice = { type: 'any' };
-                }
-            } else if (responsesRequest.tool_choice.type === 'function') {
-                claudeRequest.tool_choice = {
-                    type: 'tool',
-                    name: responsesRequest.tool_choice.function.name
-                };
-            }
+        const claudeToolChoice = this.normalizeClaudeToolChoice(responsesRequest.tool_choice);
+        if (claudeToolChoice) {
+            claudeRequest.tool_choice = claudeToolChoice;
         }
 
         return claudeRequest;

--- a/src/providers/openai/codex-core.js
+++ b/src/providers/openai/codex-core.js
@@ -652,11 +652,11 @@ export class CodexApiService {
             } else {
                 const safe = item && typeof item === 'object' ? {
                     type: item.type,
-                    id: item.id,
-                    call_id: item.call_id,
+                    hasId: typeof item.id === 'string' && item.id.length > 0,
+                    hasCallId: typeof item.call_id === 'string' && item.call_id.length > 0,
                     hasName: typeof item.name === 'string' && item.name.length > 0,
                     hasArguments: item.arguments !== undefined
-                } : item;
+                } : { valueType: typeof item };
                 logger.warn(`[Codex] Dropping malformed Responses output item from ${source}: ${JSON.stringify(safe)}`);
             }
         }
@@ -670,9 +670,9 @@ export class CodexApiService {
         if (!this.isValidCodexResponseOutputItem(eventData.item)) {
             const safe = eventData.item && typeof eventData.item === 'object' ? {
                 type: eventData.item.type,
-                id: eventData.item.id,
-                call_id: eventData.item.call_id
-            } : eventData.item;
+                hasId: typeof eventData.item.id === 'string' && eventData.item.id.length > 0,
+                hasCallId: typeof eventData.item.call_id === 'string' && eventData.item.call_id.length > 0
+            } : { valueType: typeof eventData.item };
             logger.warn(`[Codex] Dropping malformed Responses output item from response.output_item.done: ${JSON.stringify(safe)}`);
             return;
         }
@@ -695,10 +695,8 @@ export class CodexApiService {
         let output = eventData.response.output;
         if (Array.isArray(output)) {
             const sanitizedOutput = this.sanitizeCodexResponseOutputItems(output, 'response.completed.output');
-            if (sanitizedOutput.length !== output.length) {
-                eventData.response.output = sanitizedOutput;
-                output = sanitizedOutput;
-            }
+            eventData.response.output = sanitizedOutput;
+            output = sanitizedOutput;
         }
 
         const shouldPatch = (!output || !Array.isArray(output) || output.length === 0) &&

--- a/src/providers/openai/codex-core.js
+++ b/src/providers/openai/codex-core.js
@@ -403,7 +403,7 @@ export class CodexApiService {
                 cleanedBody.tools = [];
             }
             if (Array.isArray(cleanedBody.tools)) {
-                const isJsonMode = cleanedBody.text?.format?.type === 'json_object' || cleanedBody.response_format?.type === 'json_object';
+                const isJsonMode = cleanedBody.text?.format?.type === 'json_object' || cleanedBody.response_format?.type === 'json_object'; // jsonModeSkipsWebSearch
                 if (isJsonMode) {
                     cleanedBody.tools = cleanedBody.tools.filter(t => t.type !== 'web_search');
                 }

--- a/src/providers/openai/codex-core.js
+++ b/src/providers/openai/codex-core.js
@@ -622,6 +622,25 @@ export class CodexApiService {
         return true;
     }
 
+    normalizeCodexResponseOutputItem(item) { // codexResponsesOutputItemGuard
+        if (!this.isValidCodexResponseOutputItem(item)) {
+            return item;
+        }
+        if (item.type !== 'function_call') {
+            return item;
+        }
+        const itemId = typeof item.id === 'string' && item.id.trim().length > 0 ? item.id : null;
+        const callId = typeof item.call_id === 'string' && item.call_id.trim().length > 0 ? item.call_id : itemId;
+        if (!callId) {
+            return item;
+        }
+        return {
+            ...item,
+            id: itemId || callId,
+            call_id: callId
+        };
+    }
+
     sanitizeCodexResponseOutputItems(items, source) {
         if (!Array.isArray(items)) {
             return [];
@@ -629,7 +648,7 @@ export class CodexApiService {
         const valid = [];
         for (const item of items) {
             if (this.isValidCodexResponseOutputItem(item)) {
-                valid.push(item);
+                valid.push(this.normalizeCodexResponseOutputItem(item));
             } else {
                 const safe = item && typeof item === 'object' ? {
                     type: item.type,
@@ -657,10 +676,11 @@ export class CodexApiService {
             logger.warn(`[Codex] Dropping malformed Responses output item from response.output_item.done: ${JSON.stringify(safe)}`);
             return;
         }
+        const item = this.normalizeCodexResponseOutputItem(eventData.item);
         if (eventData.output_index !== undefined) {
-            outputItemsByIndex.set(eventData.output_index, eventData.item);
+            outputItemsByIndex.set(eventData.output_index, item);
         } else {
-            outputItemsFallback.push(eventData.item);
+            outputItemsFallback.push(item);
         }
     }
 
@@ -743,10 +763,12 @@ export class CodexApiService {
                             throw error;
                         }
 
-                        if ((parsed.type === 'response.output_item.added' || parsed.type === 'response.output_item.done') &&
-                            !this.isValidCodexResponseOutputItem(parsed.item)) {
-                            this.sanitizeCodexResponseOutputItems([parsed.item], parsed.type);
-                            continue;
+                        if (parsed.type === 'response.output_item.added' || parsed.type === 'response.output_item.done') {
+                            if (!this.isValidCodexResponseOutputItem(parsed.item)) {
+                                this.sanitizeCodexResponseOutputItems([parsed.item], parsed.type);
+                                continue;
+                            }
+                            parsed = { ...parsed, item: this.normalizeCodexResponseOutputItem(parsed.item) };
                         }
 
                         if (parsed.type === 'response.output_item.done') {
@@ -791,10 +813,12 @@ export class CodexApiService {
                         throw error;
                     }
 
-                    if ((parsed.type === 'response.output_item.added' || parsed.type === 'response.output_item.done') &&
-                        !this.isValidCodexResponseOutputItem(parsed.item)) {
-                        this.sanitizeCodexResponseOutputItems([parsed.item], parsed.type);
-                        return;
+                    if (parsed.type === 'response.output_item.added' || parsed.type === 'response.output_item.done') {
+                        if (!this.isValidCodexResponseOutputItem(parsed.item)) {
+                            this.sanitizeCodexResponseOutputItems([parsed.item], parsed.type);
+                            return;
+                        }
+                        parsed = { ...parsed, item: this.normalizeCodexResponseOutputItem(parsed.item) };
                     }
 
                     if (parsed.type === 'response.output_item.done') {
@@ -866,7 +890,8 @@ export class CodexApiService {
                         throw error;
                     case 'response.output_item.added':
                         if (this.isValidCodexResponseOutputItem(parsed.item)) {
-                            outputItems.set(parsed.item.id || parsed.item.call_id, parsed.item);
+                            const item = this.normalizeCodexResponseOutputItem(parsed.item);
+                            outputItems.set(item.id || item.call_id, item);
                         } else {
                             this.sanitizeCodexResponseOutputItems([parsed.item], 'response.output_item.added');
                         }

--- a/src/providers/openai/codex-core.js
+++ b/src/providers/openai/codex-core.js
@@ -403,8 +403,12 @@ export class CodexApiService {
                 cleanedBody.tools = [];
             }
             if (Array.isArray(cleanedBody.tools)) {
+                const isJsonMode = cleanedBody.text?.format?.type === 'json_object' || cleanedBody.response_format?.type === 'json_object';
+                if (isJsonMode) {
+                    cleanedBody.tools = cleanedBody.tools.filter(t => t.type !== 'web_search');
+                }
                 const hasWebSearch = cleanedBody.tools.some(t => t.type === 'web_search');
-                if (!hasWebSearch) {
+                if (!hasWebSearch && !isJsonMode) {
                     cleanedBody.tools.push({type: 'web_search'});
                 }
                 if (!upstreamModel.endsWith('spark')) {
@@ -605,11 +609,52 @@ export class CodexApiService {
         }
     }
 
+    isValidCodexResponseOutputItem(item) {
+        if (!item || typeof item.type !== 'string' || item.type.length === 0) {
+            return false;
+        }
+        if (item.type === 'function_call') {
+            const hasName = typeof item.name === 'string' && item.name.trim().length > 0;
+            const hasCallId = (typeof item.call_id === 'string' && item.call_id.trim().length > 0) ||
+                (typeof item.id === 'string' && item.id.trim().length > 0);
+            return hasName && hasCallId;
+        }
+        return true;
+    }
+
+    sanitizeCodexResponseOutputItems(items, source) {
+        if (!Array.isArray(items)) {
+            return [];
+        }
+        const valid = [];
+        for (const item of items) {
+            if (this.isValidCodexResponseOutputItem(item)) {
+                valid.push(item);
+            } else {
+                const safe = item && typeof item === 'object' ? {
+                    type: item.type,
+                    id: item.id,
+                    call_id: item.call_id,
+                    hasName: typeof item.name === 'string' && item.name.length > 0,
+                    hasArguments: item.arguments !== undefined
+                } : item;
+                logger.warn(`[Codex] Dropping malformed Responses output item from ${source}: ${JSON.stringify(safe)}`);
+            }
+        }
+        return valid;
+    }
+
     /**
      * 收集 Codex 输出项
      */
     collectCodexOutputItemDone(eventData, outputItemsByIndex, outputItemsFallback) {
-        if (!eventData.item) {
+        if (!this.isValidCodexResponseOutputItem(eventData.item)) {
+            const safe = eventData.item && typeof eventData.item === 'object' ? {
+                type: eventData.item.type,
+                id: eventData.item.id,
+                call_id: eventData.item.call_id
+            } : eventData.item;
+            logger.warn(`[Codex] Dropping malformed Responses output item from response.output_item.done: ${JSON.stringify(safe)}`);
             return;
         }
         if (eventData.output_index !== undefined) {
@@ -623,8 +668,18 @@ export class CodexApiService {
      * 修正 Codex 完成输出
      */
     patchCodexCompletedOutput(eventData, outputItemsByIndex, outputItemsFallback) {
-        const response = eventData.response || {};
-        const output = response.output;
+        if (!eventData.response) {
+            eventData.response = {};
+        }
+
+        let output = eventData.response.output;
+        if (Array.isArray(output)) {
+            const sanitizedOutput = this.sanitizeCodexResponseOutputItems(output, 'response.completed.output');
+            if (sanitizedOutput.length !== output.length) {
+                eventData.response.output = sanitizedOutput;
+                output = sanitizedOutput;
+            }
+        }
 
         const shouldPatch = (!output || !Array.isArray(output) || output.length === 0) &&
             (outputItemsByIndex.size > 0 || outputItemsFallback.length > 0);
@@ -642,10 +697,7 @@ export class CodexApiService {
         // 添加 fallback 项
         items.push(...outputItemsFallback);
 
-        if (!eventData.response) {
-            eventData.response = {};
-        }
-        eventData.response.output = items;
+        eventData.response.output = this.sanitizeCodexResponseOutputItems(items, 'collected.output_items');
 
         return eventData;
     }
@@ -675,6 +727,11 @@ export class CodexApiService {
                     try {
                         let parsed = JSON.parse(dataStr);
 
+                        if (!parsed || typeof parsed.type !== 'string') {
+                            logger.warn('[Codex] Dropping malformed SSE event without type');
+                            continue;
+                        }
+
                         if (parsed.type === 'error') {
                             logger.error('[Codex] API returned error in stream:', parsed.error || parsed);
                             const errorMsg = (parsed.error && parsed.error.message) || JSON.stringify(parsed.error || parsed);
@@ -684,6 +741,12 @@ export class CodexApiService {
                                 error.skipErrorCount = true;
                             }
                             throw error;
+                        }
+
+                        if ((parsed.type === 'response.output_item.added' || parsed.type === 'response.output_item.done') &&
+                            !this.isValidCodexResponseOutputItem(parsed.item)) {
+                            this.sanitizeCodexResponseOutputItems([parsed.item], parsed.type);
+                            continue;
                         }
 
                         if (parsed.type === 'response.output_item.done') {
@@ -712,6 +775,11 @@ export class CodexApiService {
                 try {
                     let parsed = JSON.parse(dataStr);
 
+                    if (!parsed || typeof parsed.type !== 'string') {
+                        logger.warn('[Codex] Dropping malformed final SSE event without type');
+                        return;
+                    }
+
                     if (parsed.type === 'error') {
                         logger.error('[Codex] API returned error in final stream buffer:', parsed.error || parsed);
                         const errorMsg = (parsed.error && parsed.error.message) || JSON.stringify(parsed.error || parsed);
@@ -721,6 +789,12 @@ export class CodexApiService {
                             error.skipErrorCount = true;
                         }
                         throw error;
+                    }
+
+                    if ((parsed.type === 'response.output_item.added' || parsed.type === 'response.output_item.done') &&
+                        !this.isValidCodexResponseOutputItem(parsed.item)) {
+                        this.sanitizeCodexResponseOutputItems([parsed.item], parsed.type);
+                        return;
                     }
 
                     if (parsed.type === 'response.output_item.done') {
@@ -776,6 +850,10 @@ export class CodexApiService {
 
             try {
                 let parsed = JSON.parse(jsonData);
+                if (!parsed || typeof parsed.type !== 'string') {
+                    logger.debug('[Codex] Dropping malformed non-stream event without type');
+                    continue;
+                }
                 switch (parsed.type) {
                     case 'error':
                         logger.error('[Codex] API returned error:', parsed.error || parsed);
@@ -787,8 +865,10 @@ export class CodexApiService {
                         }
                         throw error;
                     case 'response.output_item.added':
-                        if (parsed.item) {
-                            outputItems.set(parsed.item.id, parsed.item);
+                        if (this.isValidCodexResponseOutputItem(parsed.item)) {
+                            outputItems.set(parsed.item.id || parsed.item.call_id, parsed.item);
+                        } else {
+                            this.sanitizeCodexResponseOutputItems([parsed.item], 'response.output_item.added');
                         }
                         break;
                     case 'response.output_item.done':

--- a/src/providers/openai/openai-responses-strategy.js
+++ b/src/providers/openai/openai-responses-strategy.js
@@ -66,42 +66,23 @@ class ResponsesAPIStrategy extends ProviderStrategy {
             return requestBody;
         }
 
+        const existingSystemText = extractSystemPromptFromRequestBody(requestBody, MODEL_PROTOCOL_PREFIX.OPENAI_RESPONSES);
+
         const newSystemText = config.SYSTEM_PROMPT_MODE === 'append' && existingSystemText
             ? `${existingSystemText}\n${filePromptContent}`
             : filePromptContent;
 
-        // Apply system prompt replacements
         const finalSystemText = applySystemPromptReplacements(newSystemText, config.SYSTEM_PROMPT_REPLACEMENTS);
 
-        // In Responses API, system instructions are typically passed in 'instructions' field
-        // or in the input array with role: 'system'
-        requestBody.instructions = requestBody.instructions || finalSystemText;
+        const systemMessageIndex = Array.isArray(requestBody.input)
+            ? requestBody.input.findIndex(m =>
+                m.role === 'system' || m.role === 'developer' || m.type === 'system' || m.type === 'developer'
+            )
+            : -1;
 
-        // If using instructions field is not desired, append to input array instead
-        if (!requestBody.instructions || config.SYSTEM_PROMPT_MODE === 'append') {
-            if (typeof requestBody.input === 'string') {
-                // Convert to array format to add system message
-                requestBody.input = [
-                    { role: 'system', content: finalSystemText },
-                    { role: 'user', content: requestBody.input }
-                ];
-            } else if (Array.isArray(requestBody.input)) {
-                // Check if system message already exists
-                const systemMessageIndex = requestBody.input.findIndex(m =>
-                    m.role === 'system' || (m.type && m.type === 'system')
-                );
-
-                if (systemMessageIndex !== -1) {
-                    requestBody.input[systemMessageIndex].content = finalSystemText;
-                } else {
-                    requestBody.input.unshift({ role: 'system', content: finalSystemText });
-                }
-            } else {
-                // If input is not defined, initialize with system message
-                requestBody.input = [{ role: 'system', content: finalSystemText }];
-            }
-        } else if (requestBody.instructions) {
-            // If system prompt mode is not append, then replace the instructions
+        if (!requestBody.instructions && systemMessageIndex !== -1) {
+            requestBody.input[systemMessageIndex].content = finalSystemText;
+        } else {
             requestBody.instructions = finalSystemText;
         }
 

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -400,7 +400,7 @@ export function getProtocolPrefix(provider) {
 }
 
 export function getCodexResponsesStreamMode() {
-    const mode = String(process.env.CODEX_RESPONSES_STREAM_MODE || 'raw').trim().toLowerCase();
+    const mode = String(process.env.CODEX_RESPONSES_STREAM_MODE || 'canonical').trim().toLowerCase();
     return mode === 'canonical' ? 'canonical' : 'raw';
 }
 
@@ -1797,6 +1797,27 @@ export function extractSystemPromptFromRequestBody(requestBody, provider) {
                 if (Array.isArray(incomingSystemText)) {
                     incomingSystemText = incomingSystemText
                         .map(item => (typeof item === 'string' ? item : item.text || JSON.stringify(item)))
+                        .join('\n');
+                } else {
+                    incomingSystemText = JSON.stringify(incomingSystemText);
+                }
+            }
+            break;
+        case MODEL_PROTOCOL_PREFIX.OPENAI_RESPONSES:
+            if (requestBody.instructions) {
+                incomingSystemText = requestBody.instructions;
+            } else if (Array.isArray(requestBody.input)) {
+                const responsesSystemMessage = requestBody.input.find(item =>
+                    item.role === 'system' || item.role === 'developer' || item.type === 'system' || item.type === 'developer'
+                );
+                if (responsesSystemMessage?.content) {
+                    incomingSystemText = responsesSystemMessage.content;
+                }
+            }
+            if (typeof incomingSystemText === 'object' && incomingSystemText !== null) {
+                if (Array.isArray(incomingSystemText)) {
+                    incomingSystemText = incomingSystemText
+                        .map(item => (typeof item === 'string' ? item : item.text || item.content || JSON.stringify(item)))
                         .join('\n');
                 } else {
                     incomingSystemText = JSON.stringify(incomingSystemText);

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -399,6 +399,11 @@ export function getProtocolPrefix(provider) {
     return provider; // Return original if no hyphen is found
 }
 
+export function getCodexResponsesStreamMode() {
+    const mode = String(process.env.CODEX_RESPONSES_STREAM_MODE || 'raw').trim().toLowerCase();
+    return mode === 'canonical' ? 'canonical' : 'raw';
+}
+
 export const ENDPOINT_TYPE = {
     OPENAI_CHAT: 'openai_chat',
     OPENAI_RESPONSES: 'openai_responses',

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -2037,7 +2037,7 @@ function createStreamErrorResponse(error, fromProvider) {
         case MODEL_PROTOCOL_PREFIX.OPENAI_RESPONSES:
             // OpenAI Responses API 流式错误格式（SSE event + data）
             const responsesError = {
-                type: "error",
+                type: "error", // responsesStreamErrorHasType
                 id: `resp_${Date.now()}`,
                 object: "error",
                 created: Math.floor(Date.now() / 1000),

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -1972,7 +1972,7 @@ function createErrorResponse(error, fromProvider) {
  */
 function createStreamErrorResponse(error, fromProvider) {
     const protocolPrefix = getProtocolPrefix(fromProvider);
-    const rawStatusCode = error.status || error.code || 500;
+    const rawStatusCode = error.response?.status || error.status || error.statusCode || error.code || 500;
     const statusCode = ensureValidStatusCode(rawStatusCode);
     const errorMessage = error.message || "An error occurred during streaming.";
     
@@ -2011,6 +2011,7 @@ function createStreamErrorResponse(error, fromProvider) {
         case MODEL_PROTOCOL_PREFIX.OPENAI_RESPONSES:
             // OpenAI Responses API 流式错误格式（SSE event + data）
             const responsesError = {
+                type: "error",
                 id: `resp_${Date.now()}`,
                 object: "error",
                 created: Math.floor(Date.now() / 1000),

--- a/tests/api-integration.test.js
+++ b/tests/api-integration.test.js
@@ -15,8 +15,8 @@ import { fetch } from 'undici';
  */
 
 // Test server configuration
-const TEST_SERVER_BASE_URL = 'http://192.168.1.232:3000';
-const TEST_API_KEY = '123456'; // You may need to adjust this based on your server config
+const TEST_SERVER_BASE_URL = process.env.TEST_SERVER_BASE_URL || 'http://10.0.1.137:3000';
+const TEST_API_KEY = process.env.TEST_API_KEY || '123456'; // You may need to adjust this based on your server config
 const MODEL_PROVIDER = {
     // Model provider constants
     GEMINI_CLI: 'gemini-cli-oauth',

--- a/tests/api-integration.test.js
+++ b/tests/api-integration.test.js
@@ -17,6 +17,12 @@ import { fetch } from 'undici';
 // Test server configuration
 const TEST_SERVER_BASE_URL = process.env.TEST_SERVER_BASE_URL || 'http://10.0.1.137:3000';
 const TEST_API_KEY = process.env.TEST_API_KEY || '123456'; // You may need to adjust this based on your server config
+const RUN_HTTP_INTEGRATION_TESTS = process.env.RUN_HTTP_INTEGRATION_TESTS === '1';
+const RUN_PROVIDER_MATRIX_TESTS = process.env.RUN_PROVIDER_MATRIX_TESTS === '1';
+const OPENAI_RESPONSES_PROVIDER = process.env.TEST_OPENAI_RESPONSES_PROVIDER || 'openaiResponses-custom';
+const OPENAI_RESPONSES_MODEL = process.env.TEST_OPENAI_RESPONSES_MODEL || 'gpt-5.5';
+const describeIfHttp = RUN_HTTP_INTEGRATION_TESTS ? describe : describe.skip;
+const describeIfProviderMatrix = RUN_PROVIDER_MATRIX_TESTS ? describe : describe.skip;
 const MODEL_PROVIDER = {
     // Model provider constants
     GEMINI_CLI: 'gemini-cli-oauth',
@@ -78,8 +84,8 @@ const REAL_TEST_DATA = {
 };
 
 // To run all integration tests:
-// npx jest ./tests/api-integration.test.js
-describe('API Integration Tests with HTTP Requests', () => {
+// RUN_HTTP_INTEGRATION_TESTS=1 npx jest ./tests/api-integration.test.js
+describeIfHttp('API Integration Tests with HTTP Requests', () => {
     beforeAll(async () => {
         // Test server connectivity
         try {
@@ -96,9 +102,58 @@ describe('API Integration Tests with HTTP Requests', () => {
         // Jest handles test results summary automatically
     });
 
+    describe('Default OpenAI Responses Endpoint', () => {
+        test('OpenAI /v1/responses streaming smoke', async () => {
+            const response = await makeRequest(
+                `${TEST_SERVER_BASE_URL}/v1/responses`,
+                'POST',
+                'bearer',
+                { 'model-provider': OPENAI_RESPONSES_PROVIDER },
+                {
+                    model: OPENAI_RESPONSES_MODEL,
+                    input: [{
+                        role: 'user',
+                        content: [{ type: 'input_text', text: 'Reply with exactly: OK' }]
+                    }],
+                    stream: true,
+                    max_output_tokens: 32,
+                    tools: [{
+                        type: 'function',
+                        name: 'noop_tool',
+                        description: 'A no-op tool for Responses stream compatibility smoke tests.',
+                        parameters: { type: 'object', properties: {}, additionalProperties: false }
+                    }],
+                    tool_choice: 'auto'
+                }
+            );
+
+            expect(response.status).toBe(200);
+            expect(response.headers.get('content-type')).toContain('text/event-stream');
+
+            const responseText = await response.text();
+            const eventTypes = responseText
+                .split(/\r?\n/)
+                .filter(line => line.startsWith('data: '))
+                .map(line => line.slice(6).trim())
+                .filter(data => data && data !== '[DONE]')
+                .map(data => {
+                    try {
+                        return JSON.parse(data).type;
+                    } catch {
+                        return undefined;
+                    }
+                })
+                .filter(Boolean);
+
+            expect(eventTypes.length).toBeGreaterThan(0);
+            expect(eventTypes).toContain('response.created');
+            expect(eventTypes.every(type => typeof type === 'string')).toBe(true);
+        }, 60000);
+    });
+
     // To run all OpenAI Compatible Endpoints tests:
     // npx jest ./tests/api-integration.test.js -t "OpenAI Compatible Endpoints"
-    describe('OpenAI Compatible Endpoints', () => {
+    describeIfProviderMatrix('OpenAI Compatible Endpoints', () => {
         // To run this test:
         // npx jest ./tests/api-integration.test.js -t "OpenAI /v1/chat/completions non-streaming Gemini"
         test('OpenAI /v1/chat/completions non-streaming Gemini', async () => {
@@ -286,7 +341,7 @@ describe('API Integration Tests with HTTP Requests', () => {
 
     // To run all Claude Native Endpoints tests:
     // npx jest ./tests/api-integration.test.js -t "Claude Native Endpoints"
-    describe('Claude Native Endpoints', () => {
+    describeIfProviderMatrix('Claude Native Endpoints', () => {
         // To run this test:
         // npx jest ./tests/api-integration.test.js -t "Claude /v1/messages non-streaming"
         test('Claude /v1/messages non-streaming', async () => {
@@ -349,7 +404,7 @@ describe('API Integration Tests with HTTP Requests', () => {
 
     // To run all Claude Kiro Endpoints tests:
     // npx jest ./tests/api-integration.test.js -t "Claude Kiro Endpoints"
-    describe('Claude Kiro Endpoints', () => {
+    describeIfProviderMatrix('Claude Kiro Endpoints', () => {
         // To run this test:
         // npx jest ./tests/api-integration.test.js -t "Claude Kiro /v1/messages non-streaming"
         test('Claude Kiro /v1/messages non-streaming', async () => {
@@ -415,7 +470,7 @@ describe('API Integration Tests with HTTP Requests', () => {
 
     // To run all Gemini Native Endpoints tests:
     // npx jest ./tests/api-integration.test.js -t "Gemini Native Endpoints"
-    describe('Gemini Native Endpoints', () => {
+    describeIfProviderMatrix('Gemini Native Endpoints', () => {
         // To run this test:
         // npx jest ./tests/api-integration.test.js -t "Gemini /v1beta/models/{model}:generateContent"
         test('Gemini /v1beta/models/{model}:generateContent', async () => {
@@ -476,7 +531,7 @@ describe('API Integration Tests with HTTP Requests', () => {
 
     // To run all Model List Endpoints tests:
     // npx jest ./tests/api-integration.test.js -t "Model List Endpoints"
-    describe('Model List Endpoints', () => {
+    describeIfProviderMatrix('Model List Endpoints', () => {
         // To run this test:
         // npx jest ./tests/api-integration.test.js -t "OpenAI /v1/models Gemini"
         test('OpenAI /v1/models Gemini', async () => {

--- a/tests/codex-responses-compat.test.js
+++ b/tests/codex-responses-compat.test.js
@@ -256,4 +256,76 @@ describe('Codex Responses compatibility', () => {
         }
     });
 
+    test('canonical Responses stream preserves output_text.done-only text', () => {
+        const converter = new CodexConverter();
+        process.env.CODEX_RESPONSES_STREAM_MODE = 'canonical';
+        try {
+            const events = [];
+            const push = value => events.push(...(Array.isArray(value) ? value : [value]).filter(Boolean));
+
+            push(converter.toOpenAIResponsesStreamChunk({
+                type: 'response.created',
+                response: { id: 'resp_done_only', model: 'gpt-5.5' }
+            }, 'gpt-5.5', 'req_done_only'));
+            push(converter.toOpenAIResponsesStreamChunk({
+                type: 'response.output_text.done',
+                response_id: 'resp_done_only',
+                text: 'Done-only text'
+            }, 'gpt-5.5', 'req_done_only'));
+            push(converter.toOpenAIResponsesStreamChunk({
+                type: 'response.completed',
+                response: { id: 'resp_done_only', usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 } }
+            }, 'gpt-5.5', 'req_done_only'));
+
+            expect(events.map(event => event.type)).toEqual([
+                'response.created',
+                'response.in_progress',
+                'response.output_item.added',
+                'response.content_part.added',
+                'response.output_text.done',
+                'response.content_part.done',
+                'response.output_item.done',
+                'response.completed'
+            ]);
+            expect(events.find(event => event.type === 'response.output_text.done').text).toBe('Done-only text');
+            expect(events.at(-1).response.output[0].content[0].text).toBe('Done-only text');
+        } finally {
+            delete process.env.CODEX_RESPONSES_STREAM_MODE;
+        }
+    });
+
+    test('canonical Responses stream preserves completed output message text without prior delta', () => {
+        const converter = new CodexConverter();
+        process.env.CODEX_RESPONSES_STREAM_MODE = 'canonical';
+        try {
+            const events = [];
+            const push = value => events.push(...(Array.isArray(value) ? value : [value]).filter(Boolean));
+
+            push(converter.toOpenAIResponsesStreamChunk({
+                type: 'response.created',
+                response: { id: 'resp_completed_text', model: 'gpt-5.5' }
+            }, 'gpt-5.5', 'req_completed_text'));
+            push(converter.toOpenAIResponsesStreamChunk({
+                type: 'response.completed',
+                response: {
+                    id: 'resp_completed_text',
+                    output: [{
+                        id: 'msg_completed_text',
+                        type: 'message',
+                        role: 'assistant',
+                        status: 'completed',
+                        content: [{ type: 'output_text', text: 'Final output text' }]
+                    }],
+                    usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 }
+                }
+            }, 'gpt-5.5', 'req_completed_text'));
+
+            expect(events.find(event => event.type === 'response.output_text.done').text).toBe('Final output text');
+            expect(events.at(-1).response.output[0].content[0].text).toBe('Final output text');
+        } finally {
+            delete process.env.CODEX_RESPONSES_STREAM_MODE;
+        }
+    });
+
+
 });

--- a/tests/codex-responses-compat.test.js
+++ b/tests/codex-responses-compat.test.js
@@ -50,4 +50,105 @@ describe('Codex Responses compatibility', () => {
         expect(request.tools[0].name.length).toBeLessThanOrEqual(64);
         expect(request.tool_choice.name).toBe(request.tools[0].name);
     });
+
+    test('keeps Responses stream chunks raw by default', () => {
+        const converter = new CodexConverter();
+        const chunk = { type: 'response.output_text.delta', delta: 'OK' };
+        delete process.env.CODEX_RESPONSES_STREAM_MODE;
+
+        expect(converter.toOpenAIResponsesStreamChunk(chunk, 'gpt-5.5', 'req_raw')).toBe(chunk);
+    });
+
+    test('canonical Responses stream emits typed text lifecycle', () => {
+        const converter = new CodexConverter();
+        process.env.CODEX_RESPONSES_STREAM_MODE = 'canonical';
+        try {
+            const events = [];
+            const push = value => events.push(...(Array.isArray(value) ? value : [value]).filter(Boolean));
+
+            push(converter.toOpenAIResponsesStreamChunk({
+                type: 'response.created',
+                response: { id: 'resp_text', model: 'gpt-5.5' }
+            }, 'gpt-5.5', 'req_text'));
+            push(converter.toOpenAIResponsesStreamChunk({
+                type: 'response.output_text.delta',
+                response_id: 'resp_text',
+                delta: 'OK'
+            }, 'gpt-5.5', 'req_text'));
+            push(converter.toOpenAIResponsesStreamChunk({
+                type: 'response.completed',
+                response: { id: 'resp_text', usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 } }
+            }, 'gpt-5.5', 'req_text'));
+
+            expect(events.map(event => event.type)).toEqual([
+                'response.created',
+                'response.in_progress',
+                'response.output_item.added',
+                'response.content_part.added',
+                'response.output_text.delta',
+                'response.output_text.done',
+                'response.content_part.done',
+                'response.output_item.done',
+                'response.completed'
+            ]);
+            const completed = events.at(-1);
+            expect(completed.response.output[0]).toMatchObject({ type: 'message', role: 'assistant' });
+            expect(completed.response.output[0].content[0].text).toBe('OK');
+        } finally {
+            delete process.env.CODEX_RESPONSES_STREAM_MODE;
+        }
+    });
+
+    test('canonical Responses stream emits complete function_call lifecycle', () => {
+        const converter = new CodexConverter();
+        process.env.CODEX_RESPONSES_STREAM_MODE = 'canonical';
+        try {
+            const events = [];
+            const push = value => events.push(...(Array.isArray(value) ? value : [value]).filter(Boolean));
+
+            push(converter.toOpenAIResponsesStreamChunk({
+                type: 'response.created',
+                response: { id: 'resp_tool', model: 'gpt-5.5' }
+            }, 'gpt-5.5', 'req_tool'));
+            push(converter.toOpenAIResponsesStreamChunk({
+                type: 'response.output_item.done',
+                response_id: 'resp_tool',
+                output_index: 0,
+                item: {
+                    id: 'fc_1',
+                    call_id: 'call_1',
+                    type: 'function_call',
+                    name: 'get_city_time',
+                    arguments: '{"city":"Paris"}',
+                    status: 'completed'
+                }
+            }, 'gpt-5.5', 'req_tool'));
+            push(converter.toOpenAIResponsesStreamChunk({
+                type: 'response.completed',
+                response: { id: 'resp_tool', usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 } }
+            }, 'gpt-5.5', 'req_tool'));
+
+            expect(events.map(event => event.type)).toEqual([
+                'response.created',
+                'response.in_progress',
+                'response.output_item.added',
+                'response.function_call_arguments.delta',
+                'response.function_call_arguments.done',
+                'response.output_item.done',
+                'response.completed'
+            ]);
+            const completedCall = events.at(-1).response.output[0];
+            expect(completedCall).toMatchObject({
+                id: 'fc_1',
+                call_id: 'call_1',
+                type: 'function_call',
+                name: 'get_city_time',
+                arguments: '{"city":"Paris"}',
+                status: 'completed'
+            });
+        } finally {
+            delete process.env.CODEX_RESPONSES_STREAM_MODE;
+        }
+    });
+
 });

--- a/tests/codex-responses-compat.test.js
+++ b/tests/codex-responses-compat.test.js
@@ -51,12 +51,33 @@ describe('Codex Responses compatibility', () => {
         expect(request.tool_choice.name).toBe(request.tools[0].name);
     });
 
-    test('keeps Responses stream chunks raw by default', () => {
+    test('canonicalizes Responses stream chunks by default', () => {
         const converter = new CodexConverter();
-        const chunk = { type: 'response.output_text.delta', delta: 'OK' };
         delete process.env.CODEX_RESPONSES_STREAM_MODE;
 
-        expect(converter.toOpenAIResponsesStreamChunk(chunk, 'gpt-5.5', 'req_raw')).toBe(chunk);
+        const events = converter.toOpenAIResponsesStreamChunk({
+            type: 'response.output_text.delta',
+            response_id: 'resp_default',
+            delta: 'OK'
+        }, 'gpt-5.5', 'req_default');
+
+        expect(events.map(event => event.type)).toEqual([
+            'response.output_item.added',
+            'response.content_part.added',
+            'response.output_text.delta'
+        ]);
+        expect(events.at(-1).delta).toBe('OK');
+    });
+
+    test('keeps Responses stream chunks raw when explicitly requested', () => {
+        const converter = new CodexConverter();
+        const chunk = { type: 'response.output_text.delta', delta: 'OK' };
+        process.env.CODEX_RESPONSES_STREAM_MODE = 'raw';
+        try {
+            expect(converter.toOpenAIResponsesStreamChunk(chunk, 'gpt-5.5', 'req_raw')).toBe(chunk);
+        } finally {
+            delete process.env.CODEX_RESPONSES_STREAM_MODE;
+        }
     });
 
     test('canonical Responses stream emits typed text lifecycle', () => {

--- a/tests/codex-responses-compat.test.js
+++ b/tests/codex-responses-compat.test.js
@@ -328,4 +328,142 @@ describe('Codex Responses compatibility', () => {
     });
 
 
+    test('preserves Responses input developer instructions when top-level instructions are absent', () => {
+        const converter = new CodexConverter();
+        const request = converter.toOpenAIResponsesToCodexRequest({
+            model: 'gpt-5.5',
+            input: [{
+                role: 'developer',
+                content: [{ type: 'input_text', text: 'Use terse answers.' }]
+            }, {
+                role: 'user',
+                content: [{ type: 'input_text', text: 'Say OK.' }]
+            }]
+        });
+
+        expect(request.instructions).toBe('You are a helpful coding assistant.');
+        expect(request.input.map(item => item.role)).toEqual(['developer', 'user']);
+    });
+
+    test('canonical Responses stream keeps completed output ordered by emitted output indexes', () => {
+        const converter = new CodexConverter();
+        process.env.CODEX_RESPONSES_STREAM_MODE = 'canonical';
+        try {
+            const events = [];
+            const push = value => events.push(...(Array.isArray(value) ? value : [value]).filter(Boolean));
+
+            push(converter.toOpenAIResponsesStreamChunk({
+                type: 'response.created',
+                response: { id: 'resp_tool_then_text', model: 'gpt-5.5' }
+            }, 'gpt-5.5', 'req_tool_then_text'));
+            push(converter.toOpenAIResponsesStreamChunk({
+                type: 'response.output_item.done',
+                response_id: 'resp_tool_then_text',
+                output_index: 4,
+                item: {
+                    id: 'fc_first',
+                    call_id: 'call_first',
+                    type: 'function_call',
+                    name: 'get_city_time',
+                    arguments: '{"city":"Paris"}',
+                    status: 'completed'
+                }
+            }, 'gpt-5.5', 'req_tool_then_text'));
+            push(converter.toOpenAIResponsesStreamChunk({
+                type: 'response.output_text.delta',
+                response_id: 'resp_tool_then_text',
+                delta: 'Tool requested.'
+            }, 'gpt-5.5', 'req_tool_then_text'));
+            push(converter.toOpenAIResponsesStreamChunk({
+                type: 'response.completed',
+                response: { id: 'resp_tool_then_text', usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 } }
+            }, 'gpt-5.5', 'req_tool_then_text'));
+
+            expect(events.at(-1).response.output.map(item => item.type)).toEqual(['function_call', 'message']);
+        } finally {
+            delete process.env.CODEX_RESPONSES_STREAM_MODE;
+        }
+    });
+
+    test('canonical Responses stream keeps output_text.done-only text before later tool indexes', () => {
+        const converter = new CodexConverter();
+        process.env.CODEX_RESPONSES_STREAM_MODE = 'canonical';
+        try {
+            const events = [];
+            const push = value => events.push(...(Array.isArray(value) ? value : [value]).filter(Boolean));
+
+            push(converter.toOpenAIResponsesStreamChunk({
+                type: 'response.created',
+                response: { id: 'resp_done_text_tool', model: 'gpt-5.5' }
+            }, 'gpt-5.5', 'req_done_text_tool'));
+            push(converter.toOpenAIResponsesStreamChunk({
+                type: 'response.output_text.done',
+                response_id: 'resp_done_text_tool',
+                text: 'Done text first.'
+            }, 'gpt-5.5', 'req_done_text_tool'));
+            push(converter.toOpenAIResponsesStreamChunk({
+                type: 'response.output_item.done',
+                response_id: 'resp_done_text_tool',
+                output_index: 9,
+                item: {
+                    id: 'fc_after_done',
+                    call_id: 'call_after_done',
+                    type: 'function_call',
+                    name: 'get_city_time',
+                    arguments: '{"city":"Paris"}',
+                    status: 'completed'
+                }
+            }, 'gpt-5.5', 'req_done_text_tool'));
+            push(converter.toOpenAIResponsesStreamChunk({
+                type: 'response.completed',
+                response: { id: 'resp_done_text_tool', usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 } }
+            }, 'gpt-5.5', 'req_done_text_tool'));
+
+            const indexedEvents = events.filter(event => event.output_index !== undefined);
+            expect(indexedEvents.map(event => event.output_index)).toEqual([0, 0, 1, 1, 1, 1, 0, 0, 0]);
+            expect(events.at(-1).response.output.map(item => item.type)).toEqual(['message', 'function_call']);
+        } finally {
+            delete process.env.CODEX_RESPONSES_STREAM_MODE;
+        }
+    });
+
+    test('canonical Responses stream preserves image_generation_call completed output', () => {
+        const converter = new CodexConverter();
+        process.env.CODEX_RESPONSES_STREAM_MODE = 'canonical';
+        try {
+            const events = [];
+            const push = value => events.push(...(Array.isArray(value) ? value : [value]).filter(Boolean));
+            const imageCall = {
+                id: 'ig_1',
+                type: 'image_generation_call',
+                status: 'completed',
+                result: 'iVBORw0KGgo=',
+                output_format: 'png'
+            };
+
+            push(converter.toOpenAIResponsesStreamChunk({
+                type: 'response.created',
+                response: { id: 'resp_image', model: 'gpt-5.5' }
+            }, 'gpt-5.5', 'req_image'));
+            push(converter.toOpenAIResponsesStreamChunk({
+                type: 'response.completed',
+                response: {
+                    id: 'resp_image',
+                    output: [imageCall],
+                    usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 }
+                }
+            }, 'gpt-5.5', 'req_image'));
+
+            expect(events.at(-1).response.output[0]).toMatchObject({
+                id: 'ig_1',
+                type: 'image_generation_call',
+                status: 'completed'
+            });
+            expect(events.at(-1).response.output[0].output_index).toBeUndefined();
+        } finally {
+            delete process.env.CODEX_RESPONSES_STREAM_MODE;
+        }
+    });
+
+
 });

--- a/tests/codex-responses-compat.test.js
+++ b/tests/codex-responses-compat.test.js
@@ -1,0 +1,53 @@
+import { CodexConverter } from '../src/converters/strategies/CodexConverter.js';
+
+describe('Codex Responses compatibility', () => {
+    test('converts Responses tools, direct tool_choice name, and strips unsupported fields', () => {
+        const converter = new CodexConverter();
+        const request = converter.toOpenAIResponsesToCodexRequest({
+            model: 'gpt-5.5',
+            input: 'Call the tool.',
+            tools: [{
+                type: 'function',
+                name: 'get_city_time',
+                description: 'Get city time',
+                parameters: {
+                    type: 'object',
+                    properties: { city: { type: 'string' } },
+                    required: ['city'],
+                    additionalProperties: false
+                }
+            }],
+            tool_choice: { type: 'function', name: 'get_city_time' },
+            prompt_cache_retention: '24h',
+            safety_identifier: 'user-123',
+            user: 'user-123'
+        });
+
+        expect(request.instructions).toBe('You are a helpful coding assistant.');
+        expect(request.tools).toHaveLength(1);
+        expect(request.tools[0]).toMatchObject({ type: 'function', name: 'get_city_time' });
+        expect(request.tool_choice).toEqual({ type: 'function', name: 'get_city_time' });
+        expect(request.prompt_cache_retention).toBeUndefined();
+        expect(request.safety_identifier).toBeUndefined();
+        expect(request.user).toBeUndefined();
+    });
+
+    test('maps direct Responses tool_choice names through shortened tool-name map', () => {
+        const converter = new CodexConverter();
+        const longName = `mcp__server__${'x'.repeat(80)}`;
+        const request = converter.toOpenAIResponsesToCodexRequest({
+            model: 'gpt-5.5',
+            input: 'Call the tool.',
+            tools: [{
+                type: 'function',
+                name: longName,
+                description: 'Long tool name',
+                parameters: { type: 'object', properties: {} }
+            }],
+            tool_choice: { type: 'function', name: longName }
+        });
+
+        expect(request.tools[0].name.length).toBeLessThanOrEqual(64);
+        expect(request.tool_choice.name).toBe(request.tools[0].name);
+    });
+});

--- a/tests/codex-responses-compat.test.js
+++ b/tests/codex-responses-compat.test.js
@@ -151,4 +151,33 @@ describe('Codex Responses compatibility', () => {
         }
     });
 
+
+    test('normalizes Responses function_call call_id from item id', () => {
+        const converter = new CodexConverter();
+        const response = converter.toOpenAIResponsesResponse({
+            type: 'response.completed',
+            response: {
+                id: 'resp_tool',
+                model: 'gpt-5.5',
+                output: [{
+                    id: 'fc_1',
+                    type: 'function_call',
+                    name: 'get_probe',
+                    arguments: '{}',
+                    status: 'completed'
+                }],
+                usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 }
+            }
+        }, 'gpt-5.5');
+
+        expect(response.output[0]).toMatchObject({
+            id: 'fc_1',
+            call_id: 'fc_1',
+            type: 'function_call',
+            name: 'get_probe',
+            arguments: '{}',
+            status: 'completed'
+        });
+    });
+
 });

--- a/tests/codex-responses-compat.test.js
+++ b/tests/codex-responses-compat.test.js
@@ -180,4 +180,80 @@ describe('Codex Responses compatibility', () => {
         });
     });
 
+
+    test('canonical Responses stream densifies sparse upstream function_call indexes', () => {
+        const converter = new CodexConverter();
+        process.env.CODEX_RESPONSES_STREAM_MODE = 'canonical';
+        try {
+            const events = [];
+            const push = value => events.push(...(Array.isArray(value) ? value : [value]).filter(Boolean));
+
+            push(converter.toOpenAIResponsesStreamChunk({
+                type: 'response.created',
+                response: { id: 'resp_sparse_tool', model: 'gpt-5.5' }
+            }, 'gpt-5.5', 'req_sparse_tool'));
+            push(converter.toOpenAIResponsesStreamChunk({
+                type: 'response.output_item.done',
+                response_id: 'resp_sparse_tool',
+                output_index: 3,
+                item: {
+                    id: 'fc_sparse',
+                    call_id: 'call_sparse',
+                    type: 'function_call',
+                    name: 'get_city_time',
+                    arguments: '{"city":"Paris"}',
+                    status: 'completed'
+                }
+            }, 'gpt-5.5', 'req_sparse_tool'));
+
+            const functionEvents = events.filter(event => event.output_index !== undefined);
+            expect(functionEvents.map(event => event.output_index)).toEqual([0, 0, 0, 0]);
+            expect(functionEvents.map(event => event.type)).toEqual([
+                'response.output_item.added',
+                'response.function_call_arguments.delta',
+                'response.function_call_arguments.done',
+                'response.output_item.done'
+            ]);
+        } finally {
+            delete process.env.CODEX_RESPONSES_STREAM_MODE;
+        }
+    });
+
+    test('canonical Responses stream keeps text and sparse function_call indexes dense', () => {
+        const converter = new CodexConverter();
+        process.env.CODEX_RESPONSES_STREAM_MODE = 'canonical';
+        try {
+            const events = [];
+            const push = value => events.push(...(Array.isArray(value) ? value : [value]).filter(Boolean));
+
+            push(converter.toOpenAIResponsesStreamChunk({
+                type: 'response.created',
+                response: { id: 'resp_text_tool_sparse', model: 'gpt-5.5' }
+            }, 'gpt-5.5', 'req_text_tool_sparse'));
+            push(converter.toOpenAIResponsesStreamChunk({
+                type: 'response.output_text.delta',
+                response_id: 'resp_text_tool_sparse',
+                delta: 'Need a tool.'
+            }, 'gpt-5.5', 'req_text_tool_sparse'));
+            push(converter.toOpenAIResponsesStreamChunk({
+                type: 'response.output_item.done',
+                response_id: 'resp_text_tool_sparse',
+                output_index: 5,
+                item: {
+                    id: 'fc_after_text',
+                    call_id: 'call_after_text',
+                    type: 'function_call',
+                    name: 'get_city_time',
+                    arguments: '{"city":"Paris"}',
+                    status: 'completed'
+                }
+            }, 'gpt-5.5', 'req_text_tool_sparse'));
+
+            const indexedEvents = events.filter(event => event.output_index !== undefined);
+            expect(indexedEvents.map(event => event.output_index)).toEqual([0, 0, 0, 1, 1, 1, 1]);
+        } finally {
+            delete process.env.CODEX_RESPONSES_STREAM_MODE;
+        }
+    });
+
 });

--- a/tests/openai-responses-compat.test.js
+++ b/tests/openai-responses-compat.test.js
@@ -1,0 +1,48 @@
+import { OpenAIResponsesConverter } from '../src/converters/strategies/OpenAIResponsesConverter.js';
+import { ResponsesAPIStrategy } from '../src/providers/openai/openai-responses-strategy.js';
+import { extractSystemPromptFromRequestBody, MODEL_PROTOCOL_PREFIX } from '../src/utils/common.js';
+
+describe('OpenAI Responses compatibility', () => {
+    test('extracts system prompt from Responses instructions and input messages', () => {
+        expect(extractSystemPromptFromRequestBody({
+            instructions: 'Be precise.'
+        }, MODEL_PROTOCOL_PREFIX.OPENAI_RESPONSES)).toBe('Be precise.');
+
+        expect(extractSystemPromptFromRequestBody({
+            input: [{ role: 'system', content: [{ type: 'input_text', text: 'Be safe.' }] }]
+        }, MODEL_PROTOCOL_PREFIX.OPENAI_RESPONSES)).toBe('Be safe.');
+    });
+
+    test('applies Responses system prompt file without ReferenceError', async () => {
+        const strategy = new ResponsesAPIStrategy();
+        const requestBody = { instructions: 'Original', input: 'Hello' };
+
+        const result = await strategy.applySystemPromptFromFile({
+            SYSTEM_PROMPT_FILE_PATH: 'prompt.txt',
+            SYSTEM_PROMPT_CONTENT: 'File prompt',
+            SYSTEM_PROMPT_MODE: 'append',
+            SYSTEM_PROMPT_REPLACEMENTS: []
+        }, requestBody);
+
+        expect(result.instructions).toBe('Original\nFile prompt');
+        expect(result.input).toBe('Hello');
+    });
+
+    test('normalizes direct Responses tool_choice for Chat Completions and Claude', () => {
+        const converter = new OpenAIResponsesConverter();
+        const request = {
+            model: 'gpt-5.5',
+            input: [{ role: 'user', content: 'Call the tool.' }],
+            tool_choice: { type: 'function', name: 'get_city_time' }
+        };
+
+        expect(converter.toOpenAIRequest(request).tool_choice).toEqual({
+            type: 'function',
+            function: { name: 'get_city_time' }
+        });
+        expect(converter.toClaudeRequest(request).tool_choice).toEqual({
+            type: 'tool',
+            name: 'get_city_time'
+        });
+    });
+});


### PR DESCRIPTION
## Summary

This draft improves **Codex OAuth compatibility with OpenAI Responses API clients**.

The branch is intentionally kept as a draft because it groups several related compatibility fixes. It is useful as a review bundle, but I expect it may be cleaner to split after maintainer feedback.

## Problem

Codex Responses-compatible traffic is close to OpenAI Responses, but there are several edge cases that can break stricter clients:

1. Some OpenAI Responses request fields are not accepted by the Codex upstream and must be stripped or converted.
2. `tool_choice` can arrive in shapes that OpenAI-compatible clients emit but Codex does not accept directly.
3. AIClient2API currently injects a default Codex `web_search` tool for non-image requests; that default tool must not be injected when the request is in JSON mode, because Codex rejects JSON-mode requests that include `web_search`.
4. Stream error envelopes should have a top-level typed event shape.
5. Some completed/output-item stream objects can be malformed or missing required function-call fields.
6. Codex function calls can contain `id` but no `call_id`, while Responses clients may rely on `call_id`.
7. Codex streams can contain sparse upstream `output_index` values. Clients that treat `output_index` as an array index can get holes/placeholders.
8. Assistant text may arrive only in `done`/`completed` events rather than `output_text.delta`, so final visible text can be lost if the converter only trusts deltas.

## What Changed

### Request conversion compatibility

- Strip or convert unsupported Responses request fields before forwarding to Codex.
- Convert direct and nested function `tool_choice` shapes.
- Preserve developer/system input messages when no explicit top-level `instructions` were provided.
- Preserve existing behavior where possible, but avoid forwarding request shapes known to produce Codex-side 400s.

### JSON mode guard

- Do **not** remove web search globally.
- Do **not** change headers.
- Only prevent AIClient2API from auto-injecting the default Codex `{ type: "web_search" }` tool into requests that explicitly ask for JSON mode.
- Also remove `web_search` from the outgoing `tools` array for JSON-mode requests, because Codex rejects the combination.

In short: normal requests can still use the default `web_search` behavior; JSON-mode requests avoid `web_search` because Codex does not accept that combination.

### Stream/output hardening

- Ensure stream error envelopes are typed with top-level `type: "error"`.
- Drop malformed completed output items before returning them to OpenAI Responses clients.
- Drop malformed `response.output_item.added` / `response.output_item.done` entries when required fields are missing.
- Normalize `function_call.call_id` from `id` when Codex only provides `id`.
- Avoid logging raw malformed output-item identifiers/payload values; log structural booleans instead.

### Optional canonical Responses stream mode

Adds:

```text
CODEX_RESPONSES_STREAM_MODE=raw|canonical
```

- `raw`: keep the prior passthrough/sanitized stream behavior.
- `canonical`: rebuild a minimal typed OpenAI Responses lifecycle for text, function calls, and image-generation output items.

Canonical mode emits dense local indexes instead of reusing sparse upstream indexes. For example:

```text
upstream tool output_index: 3
emitted canonical tool lifecycle indexes: [0, 0, 0, 0]
```

For mixed text + tool calls:

```text
text local index: 0
first function_call local index: 1
```

This avoids exposing sparse output arrays to clients that assume `output_index` is dense.

### Completed-text preservation

Canonical mode now preserves assistant text even when it arrives only via:

- `response.output_text.done`
- `response.content_part.done`
- `response.output_item.done` with `type: "message"`
- final `response.completed.response.output`

The converter then emits final typed text lifecycle events and a completed message output containing the actual assistant text.

### Local review fixes added after 10 review passes

A local 10-pass review found and fixed additional issues before marking the draft ready for maintainer review:

- developer/system input messages were being dropped when default `instructions` were injected too early;
- done-only text could reserve its output index too late when a tool call followed;
- completed output order could diverge from emitted stream `output_index` order;
- canonical mode could drop `image_generation_call` output from `response.completed`;
- completed output normalization needed to write back normalized `call_id` even when the item count did not change;
- malformed output logging now avoids raw ids/call_ids.

## Files Touched

- `src/converters/strategies/CodexConverter.js`
  - request/response conversion compatibility;
  - canonical stream event generation;
  - dense `output_index` mapping;
  - final/done text extraction and completed message output construction;
  - image_generation_call preservation in canonical completed output.
- `src/providers/openai/codex-core.js`
  - Codex stream output-item validation/hardening;
  - function-call `call_id` normalization;
  - stream malformed-output filtering;
  - safer structural malformed-output logging.
- `src/utils/common.js`
  - `CODEX_RESPONSES_STREAM_MODE` helper.
- `tests/codex-responses-compat.test.js`
  - regression coverage for request conversion, raw/canonical behavior, function calls, dense indexes, done/completed-only text, developer input preservation, ordering, and image-generation output preservation.

## Regression Coverage

The focused compatibility suite covers:

- Responses tools conversion and unsupported field stripping.
- Direct function `tool_choice` mapping.
- Raw stream passthrough by default.
- Canonical text lifecycle emission.
- Canonical function-call lifecycle emission.
- `call_id` normalization from `id`.
- Sparse function-call upstream indexes becoming dense local indexes.
- Text + sparse function-call streams keeping indexes dense.
- `output_text.done`-only assistant text preservation.
- final `response.completed.output` message text preservation without prior deltas.
- developer input preservation when top-level `instructions` are absent.
- final completed output order matching emitted local `output_index` order.
- done-only text reserving its text index before later tool calls.
- `image_generation_call` preservation in canonical completed output.

## Validation

Passed locally:

```bash
npm test -- --runInBand tests/codex-responses-compat.test.js
node --check src/converters/strategies/CodexConverter.js
node --check src/providers/openai/codex-core.js
node --check src/utils/common.js
node --check tests/codex-responses-compat.test.js
```

Focused suite result: **14/14 tests passed**.

## Compatibility / Risk Notes

- Raw mode remains available and is still the safe fallback: `CODEX_RESPONSES_STREAM_MODE=raw`.
- Canonical mode is opt-in via env var and intended for clients that require stricter OpenAI Responses stream shapes.
- Malformed output filtering is intentionally conservative: invalid output entries are dropped rather than passed downstream as ambiguous `{}` / incomplete objects.
- The branch may be split into smaller PRs if maintainers prefer narrower review units.

Suggested split if desired:

1. Request conversion compatibility.
2. JSON mode / default `web_search` guard.
3. Malformed output + `call_id` hardening.
4. Optional canonical stream mode with dense indexes and final text/image output preservation.

## Privacy / Scope Note

This PR description intentionally avoids any private deployment details, account identifiers, logs, prompts, or client-specific session data. The change should be reviewed as a general OpenAI Responses compatibility improvement for Codex OAuth streams.
