### PR TITLE
fix: complete Responses image generation calls with results

### DIFF
--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -96,12 +96,34 @@ function hasNonEmptyString(value) {
     return typeof value === 'string' && value.trim().length > 0;
 }
 
-function normalizeImageGenerationItemStatus(item) {
+const IMAGE_GENERATION_NON_COMPLETED_STATUSES = new Set([
+    'failed',
+    'incomplete',
+    'cancelled',
+    'canceled',
+    'error'
+]);
+
+function isCompletedStatus(value) {
+    return typeof value === 'string' && value.toLowerCase() === 'completed';
+}
+
+function isNonCompletedTerminalStatus(value) {
+    return typeof value === 'string' && IMAGE_GENERATION_NON_COMPLETED_STATUSES.has(value.toLowerCase());
+}
+
+function normalizeImageGenerationItemStatus(item, terminalContext = false) {
     if (!item || typeof item !== 'object') {
         return item;
     }
 
-    if (item.type === 'image_generation_call' && hasNonEmptyString(item.result)) {
+    if (
+        terminalContext &&
+        item.type === 'image_generation_call' &&
+        hasNonEmptyString(item.result) &&
+        !isCompletedStatus(item.status) &&
+        !isNonCompletedTerminalStatus(item.status)
+    ) {
         return {
             ...item,
             status: 'completed'
@@ -111,12 +133,12 @@ function normalizeImageGenerationItemStatus(item) {
     return item;
 }
 
-function normalizeImageGenerationOutputItems(output) {
+function normalizeImageGenerationOutputItems(output, terminalContext = false) {
     if (!Array.isArray(output)) {
         return output;
     }
 
-    return output.map(normalizeImageGenerationItemStatus);
+    return output.map(item => normalizeImageGenerationItemStatus(item, terminalContext));
 }
 
 export function normalizeResponsesImageGenerationStatus(payload) {
@@ -125,19 +147,24 @@ export function normalizeResponsesImageGenerationStatus(payload) {
     }
 
     const normalized = { ...payload };
+    const eventType = normalized.type;
+    const isOutputItemDone = eventType === 'response.output_item.done';
+    const isResponseCompletedEvent = eventType === 'response.completed';
+    const isCompletedResponse = isCompletedStatus(normalized.status);
 
     if (Array.isArray(normalized.output)) {
-        normalized.output = normalizeImageGenerationOutputItems(normalized.output);
+        normalized.output = normalizeImageGenerationOutputItems(normalized.output, isCompletedResponse);
     }
 
     if (normalized.item && typeof normalized.item === 'object') {
-        normalized.item = normalizeImageGenerationItemStatus(normalized.item);
+        normalized.item = normalizeImageGenerationItemStatus(normalized.item, isOutputItemDone);
     }
 
     if (normalized.response && typeof normalized.response === 'object') {
+        const responseCompleted = isResponseCompletedEvent || isCompletedStatus(normalized.response.status);
         normalized.response = {
             ...normalized.response,
-            output: normalizeImageGenerationOutputItems(normalized.response.output)
+            output: normalizeImageGenerationOutputItems(normalized.response.output, responseCompleted)
         };
     }
 

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -92,6 +92,58 @@ function getHeaderValue(headers, headerName) {
     return null;
 }
 
+function hasNonEmptyString(value) {
+    return typeof value === 'string' && value.trim().length > 0;
+}
+
+function normalizeImageGenerationItemStatus(item) {
+    if (!item || typeof item !== 'object') {
+        return item;
+    }
+
+    if (item.type === 'image_generation_call' && hasNonEmptyString(item.result)) {
+        return {
+            ...item,
+            status: 'completed'
+        };
+    }
+
+    return item;
+}
+
+function normalizeImageGenerationOutputItems(output) {
+    if (!Array.isArray(output)) {
+        return output;
+    }
+
+    return output.map(normalizeImageGenerationItemStatus);
+}
+
+export function normalizeResponsesImageGenerationStatus(payload) {
+    if (!payload || typeof payload !== 'object') {
+        return payload;
+    }
+
+    const normalized = { ...payload };
+
+    if (Array.isArray(normalized.output)) {
+        normalized.output = normalizeImageGenerationOutputItems(normalized.output);
+    }
+
+    if (normalized.item && typeof normalized.item === 'object') {
+        normalized.item = normalizeImageGenerationItemStatus(normalized.item);
+    }
+
+    if (normalized.response && typeof normalized.response === 'object') {
+        normalized.response = {
+            ...normalized.response,
+            output: normalizeImageGenerationOutputItems(normalized.response.output)
+        };
+    }
+
+    return normalized;
+}
+
 function parseRetryAfterMs(value, now = Date.now()) {
     if (value === null || value === undefined) return null;
 
@@ -697,7 +749,8 @@ export async function handleStreamRequest(res, service, model, requestBody, from
             // 处理 chunkToSend 可能是数组或对象的情况
             const chunksToSend = Array.isArray(chunkToSend) ? chunkToSend : [chunkToSend];
 
-            for (const chunk of chunksToSend) {
+            for (const rawChunk of chunksToSend) {
+                const chunk = normalizeResponsesImageGenerationStatus(rawChunk);
                 // 再次检查客户端连接状态
                 if (clientDisconnected.value) {
                     break;
@@ -992,6 +1045,7 @@ export async function handleUnaryRequest(res, service, model, requestBody, fromP
             logger.info(`[Response Convert] Converting response from ${toProvider} to ${fromProvider}`);
             clientResponse = convertData(nativeResponse, 'response', toProvider, fromProvider, model);
         }
+        clientResponse = normalizeResponsesImageGenerationStatus(clientResponse);
 
         // 监控钩子：非流式响应
         const hookRequestId = getPluginHookRequestId(CONFIG);

--- a/tests/responses-image-status-normalize.test.js
+++ b/tests/responses-image-status-normalize.test.js
@@ -68,4 +68,66 @@ describe('Responses image generation status normalization', () => {
 
         expect(event.item.status).toBe('in_progress');
     });
+
+    test('does not mark non-terminal stream image items as completed even with a result', () => {
+        const event = normalizeResponsesImageGenerationStatus({
+            type: 'response.output_item.added',
+            output_index: 0,
+            item: {
+                id: 'ig_1',
+                type: 'image_generation_call',
+                status: 'in_progress',
+                result: 'partial-or-provider-specific-value'
+            }
+        });
+
+        expect(event.item.status).toBe('in_progress');
+    });
+
+    test('does not mark non-completed response output image calls as completed', () => {
+        const response = normalizeResponsesImageGenerationStatus({
+            id: 'resp_1',
+            status: 'in_progress',
+            output: [{
+                id: 'ig_1',
+                type: 'image_generation_call',
+                status: 'in_progress',
+                result: 'partial-or-provider-specific-value'
+            }]
+        });
+
+        expect(response.output[0].status).toBe('in_progress');
+    });
+
+    test('preserves failed image calls even when a terminal payload includes a result', () => {
+        const event = normalizeResponsesImageGenerationStatus({
+            type: 'response.completed',
+            response: {
+                id: 'resp_1',
+                status: 'completed',
+                output: [{
+                    id: 'ig_1',
+                    type: 'image_generation_call',
+                    status: 'failed',
+                    result: 'provider-error-or-debug-payload'
+                }]
+            }
+        });
+
+        expect(event.response.output[0].status).toBe('failed');
+    });
+
+    test('marks terminal image calls without a status but with result as completed', () => {
+        const event = normalizeResponsesImageGenerationStatus({
+            type: 'response.output_item.done',
+            output_index: 0,
+            item: {
+                id: 'ig_1',
+                type: 'image_generation_call',
+                result: 'iVBORw0KGgo='
+            }
+        });
+
+        expect(event.item.status).toBe('completed');
+    });
 });

--- a/tests/responses-image-status-normalize.test.js
+++ b/tests/responses-image-status-normalize.test.js
@@ -1,0 +1,71 @@
+import { normalizeResponsesImageGenerationStatus } from '../src/utils/common.js';
+
+describe('Responses image generation status normalization', () => {
+    test('marks completed response output image calls with result as completed', () => {
+        const response = normalizeResponsesImageGenerationStatus({
+            id: 'resp_1',
+            status: 'completed',
+            output: [{
+                id: 'ig_1',
+                type: 'image_generation_call',
+                status: 'generating',
+                result: 'iVBORw0KGgo=',
+                output_format: 'png'
+            }]
+        });
+
+        expect(response.output[0]).toMatchObject({
+            id: 'ig_1',
+            type: 'image_generation_call',
+            status: 'completed',
+            result: 'iVBORw0KGgo='
+        });
+    });
+
+    test('marks stream terminal image items with result as completed', () => {
+        const event = normalizeResponsesImageGenerationStatus({
+            type: 'response.output_item.done',
+            output_index: 0,
+            item: {
+                id: 'ig_1',
+                type: 'image_generation_call',
+                status: 'generating',
+                result: 'iVBORw0KGgo='
+            }
+        });
+
+        expect(event.item.status).toBe('completed');
+    });
+
+    test('marks completed event output image calls with result as completed', () => {
+        const event = normalizeResponsesImageGenerationStatus({
+            type: 'response.completed',
+            response: {
+                id: 'resp_1',
+                status: 'completed',
+                output: [{
+                    id: 'ig_1',
+                    type: 'image_generation_call',
+                    status: 'generating',
+                    result: 'iVBORw0KGgo='
+                }]
+            }
+        });
+
+        expect(event.response.output[0].status).toBe('completed');
+    });
+
+    test('does not mark in-progress image calls without result as completed', () => {
+        const event = normalizeResponsesImageGenerationStatus({
+            type: 'response.output_item.added',
+            output_index: 0,
+            item: {
+                id: 'ig_1',
+                type: 'image_generation_call',
+                status: 'in_progress'
+            }
+        });
+
+        expect(event.item.status).toBe('in_progress');
+    });
+});


### PR DESCRIPTION
## Summary

Normalize OpenAI Responses `image_generation_call` items that already contain a final `result` so they are returned with `status: "completed"` instead of preserving an upstream/intermediate `status: "generating"`.

## Why

Some Responses image generation flows can produce a completed response and a valid base64 PNG in `image_generation_call.result`, while the output item still has `status: "generating"`.

That shape is confusing for strict Responses clients: the image payload is present, but the item still looks unfinished. In practice this can lead clients to treat the image result as blank or still pending.

The affected shapes are:

- non-stream `response.output[]`
- stream `response.output_item.done.item`
- stream `response.completed.response.output[]`

The fix is intentionally conservative: only `image_generation_call` items with a non-empty `result` are marked completed. In-progress image calls without a result are left unchanged.

## Validation

```bash
node --check src/utils/common.js
npm test -- --runInBand tests/responses-image-status-normalize.test.js
```

Local result:

```text
PASS tests/responses-image-status-normalize.test.js
4 passed
```

Also validated against a live OpenAI Responses-compatible route:

- non-stream image response: top-level `response.status=completed`, image item has non-empty `result`, normalized to `status=completed`
- stream image response: `response.output_item.done.item.status=completed`
- stream completed response: `response.completed.output[0].status=completed`
- decoded image payload is a valid PNG
