### PR TITLE
fix: 修复claude custom格式转openai 格式代理商格式错误问题

### DIFF
--- a/src/converters/strategies/ClaudeConverter.js
+++ b/src/converters/strategies/ClaudeConverter.js
@@ -3,39 +3,36 @@
  * 处理Claude（Anthropic）协议与其他协议之间的转换
  */
 
-import { v4 as uuidv4 } from 'uuid';
+import {v4 as uuidv4} from 'uuid';
 import logger from '../../utils/logger.js';
-import { BaseConverter } from '../BaseConverter.js';
+import {BaseConverter} from '../BaseConverter.js';
 import {
     checkAndAssignOrDefault,
-    cleanJsonSchemaProperties as cleanJsonSchema,
+    cleanJsonSchemaForOpenAI,
     determineReasoningEffortFromBudget,
+    GEMINI_DEFAULT_INPUT_TOKEN_LIMIT,
+    GEMINI_DEFAULT_OUTPUT_TOKEN_LIMIT,
     OPENAI_DEFAULT_MAX_TOKENS,
     OPENAI_DEFAULT_TEMPERATURE,
-    OPENAI_DEFAULT_TOP_P,
-    GEMINI_DEFAULT_MAX_TOKENS,
-    GEMINI_DEFAULT_TEMPERATURE,
-    GEMINI_DEFAULT_TOP_P,
-    GEMINI_DEFAULT_INPUT_TOKEN_LIMIT,
-    GEMINI_DEFAULT_OUTPUT_TOKEN_LIMIT
+    OPENAI_DEFAULT_TOP_P
 } from '../utils.js';
-import { MODEL_PROTOCOL_PREFIX } from '../../utils/common.js';
+import {MODEL_PROTOCOL_PREFIX} from '../../utils/common.js';
 import {
-    generateResponseCreated,
-    generateResponseInProgress,
-    generateOutputItemAdded,
-    generateContentPartAdded,
-    generateOutputTextDone,
-    generateContentPartDone,
-    generateOutputItemDone,
-    generateResponseCompleted,
-    generateOutputTextDelta,
-    streamStateManager,
-    startToolCall,
     finishToolCall,
+    generateContentPartAdded,
+    generateContentPartDone,
     generateFunctionCallArgsDelta,
     generateFunctionCallArgsDone,
-    generateFunctionCallOutputItemDone
+    generateFunctionCallOutputItemDone,
+    generateOutputItemAdded,
+    generateOutputItemDone,
+    generateOutputTextDelta,
+    generateOutputTextDone,
+    generateResponseCompleted,
+    generateResponseCreated,
+    generateResponseInProgress,
+    startToolCall,
+    streamStateManager
 } from '../../providers/openai/openai-responses-core.mjs';
 
 /**
@@ -135,6 +132,13 @@ export class ClaudeConverter extends BaseConverter {
 
         // 处理消息
         if (claudeRequest.messages && Array.isArray(claudeRequest.messages)) {
+            // thinking 模式启用（enabled / adaptive）时，上游
+            // （DeepSeek / Kimi / SiliconFlow / iFlow / GLM-4.6 / MiniMax M2 等）
+            // 强制要求带 tool_calls 的 assistant 消息携带 reasoning_content 字段，缺失即 400。
+            // 字段存在即可，值可为空字符串（客户端历史未保留 thinking 块时的兜底）。
+            const thinkingType = claudeRequest.thinking && claudeRequest.thinking.type;
+            const thinkingEnabled = thinkingType === "enabled" || thinkingType === "adaptive";
+
             const tempOpenAIMessages = [];
             for (const msg of claudeRequest.messages) {
                 const role = msg.role;
@@ -166,37 +170,64 @@ export class ClaudeConverter extends BaseConverter {
                     }
                 }
 
+                // 抽取 assistant 消息中的 thinking 块作为 reasoning_content
+                let reasoningContent = '';
+                if (role === "assistant" && Array.isArray(msg.content)) {
+                    const reasoningParts = [];
+                    for (const block of msg.content) {
+                        if (block && typeof block === 'object' && block.type === 'thinking' && block.thinking) {
+                            reasoningParts.push(typeof block.thinking === 'string' ? block.thinking : String(block.thinking));
+                        }
+                    }
+                    if (reasoningParts.length > 0) {
+                        reasoningContent = reasoningParts.join('\n');
+                    }
+                }
+
                 // 处理assistant消息中的工具调用
                 if (role === "assistant" && Array.isArray(msg.content) && msg.content.length > 0) {
-                    const firstPart = msg.content[0];
-                    if (firstPart.type === "tool_use") {
-                        const funcName = firstPart.name || "";
-                        const funcArgs = firstPart.input || {};
-                        tempOpenAIMessages.push({
+                    const toolUsePart = msg.content.find(b => b && b.type === "tool_use");
+                    if (toolUsePart) {
+                        const funcName = toolUsePart.name || "";
+                        const funcArgs = toolUsePart.input || {};
+                        const toolCallMsg = {
                             role: "assistant",
                             content: '',
                             tool_calls: [
                                 {
-                                    id: firstPart.id || `call_${funcName}_1`,
+                                    id: toolUsePart.id || `call_${funcName}_1`,
                                     type: "function",
                                     function: {
                                         name: funcName,
                                         arguments: JSON.stringify(funcArgs)
                                     },
-                                    index: firstPart.index || 0
+                                    index: toolUsePart.index || 0
                                 }
                             ]
-                        });
+                        };
+                        // 带 tool_calls 的 assistant 消息：thinking 启用则强制携带 reasoning_content（空串兜底）
+                        if (thinkingEnabled || reasoningContent) {
+                            toolCallMsg.reasoning_content = reasoningContent;
+                        }
+                        tempOpenAIMessages.push(toolCallMsg);
                         continue;
                     }
                 }
 
                 // 普通文本消息
                 const contentConverted = this.processClaudeContentToOpenAIContent(msg.content || "");
-                if (contentConverted && (Array.isArray(contentConverted) ? contentConverted.length > 0 : contentConverted.trim().length > 0)) {
+                const hasContent = contentConverted && (Array.isArray(contentConverted) ? contentConverted.length > 0 : contentConverted.trim().length > 0);
+                if (hasContent) {
+                    const openaiMsg = { role: role, content: contentConverted };
+                    if (reasoningContent) {
+                        openaiMsg.reasoning_content = reasoningContent;
+                    }
+                    tempOpenAIMessages.push(openaiMsg);
+                } else if (reasoningContent) {
                     tempOpenAIMessages.push({
                         role: role,
-                        content: contentConverted
+                        content: '',
+                        reasoning_content: reasoningContent
                     });
                 }
             }
@@ -246,7 +277,7 @@ export class ClaudeConverter extends BaseConverter {
                     function: {
                         name: tool.name || "",
                         description: tool.description || "",
-                        parameters: cleanJsonSchema(tool.input_schema || {})
+                        parameters: cleanJsonSchemaForOpenAI(tool.input_schema || {})
                     }
                 });
             }
@@ -254,10 +285,23 @@ export class ClaudeConverter extends BaseConverter {
             openaiRequest.tool_choice = "auto";
         }
 
-        // 处理thinking转换
-        if (claudeRequest.thinking && claudeRequest.thinking.type === "enabled") {
+        // 处理thinking转换（enabled / adaptive 都映射为 OpenAI reasoning_effort）
+        const _thinkingType = claudeRequest.thinking && claudeRequest.thinking.type;
+        if (_thinkingType === "enabled" || _thinkingType === "adaptive") {
+            // adaptive 没有 budget_tokens，effort 来自 output_config.effort（high/medium/low/xhigh/max）
+            // enabled 则按 budget_tokens 推算
+            // OpenAI 兼容上游只接受 low/medium/high，需收敛 max/xhigh -> high
+            const effortFromConfig = claudeRequest.output_config && claudeRequest.output_config.effort;
             const budgetTokens = claudeRequest.thinking.budget_tokens;
-            const reasoningEffort = determineReasoningEffortFromBudget(budgetTokens);
+            let reasoningEffort = effortFromConfig
+                ? String(effortFromConfig).toLowerCase()
+                : determineReasoningEffortFromBudget(budgetTokens);
+            if (reasoningEffort === "max" || reasoningEffort === "xhigh") {
+                reasoningEffort = "high";
+            }
+            if (!["low", "medium", "high"].includes(reasoningEffort)) {
+                reasoningEffort = "high";
+            }
             openaiRequest.reasoning_effort = reasoningEffort;
 
             let maxCompletionTokens = null;

--- a/src/converters/utils.js
+++ b/src/converters/utils.js
@@ -178,6 +178,139 @@ export function extractAndProcessSystemMessages(messages, replacements = []) {
     return { systemInstruction, nonSystemMessages };
 }
 
+// JSON Schema 清理配置常量
+const GEMINI_ALLOWED_KEYS = [
+    "type",
+    "description",
+    "properties",
+    "required",
+    "enum",
+    "items",
+    "nullable"
+];
+
+const OPENAI_EXCLUDED_KEYS = ['$schema'];
+
+/**
+ * 规范化 type 字段值
+ * @param {string|Array} typeValue - type 字段的原始值
+ * @param {Function} caseTransform - 大小写转换函数 (toUpperCase 或 toLowerCase)
+ * @returns {string|undefined} 规范化后的 type 值
+ */
+function normalizeTypeField(typeValue, caseTransform) {
+    if (Array.isArray(typeValue)) {
+        const actualType = typeValue.find(t => t !== 'null');
+        return actualType ? caseTransform(actualType) : undefined;
+    }
+
+    if (typeof typeValue === 'string') {
+        return caseTransform(typeValue);
+    }
+
+    return undefined;
+}
+
+/**
+ * 递归清理 properties 对象
+ * @param {Object} properties - properties 对象
+ * @param {Function} cleanFn - 清理函数
+ * @returns {Object} 清理后的 properties
+ */
+function cleanPropertiesRecursively(properties, cleanFn) {
+    const cleaned = {};
+    for (const [propName, propSchema] of Object.entries(properties)) {
+        cleaned[propName] = cleanFn(propSchema);
+    }
+    return cleaned;
+}
+
+/**
+ * 处理 type 字段（Gemini 格式）
+ * @param {Object} sanitized - 目标对象
+ * @param {string|Array} typeValue - type 字段值
+ */
+function handleGeminiTypeField(sanitized, typeValue) {
+    if (Array.isArray(typeValue) && typeValue.includes('null')) {
+        sanitized.nullable = true;
+    }
+
+    const normalizedType = normalizeTypeField(typeValue, t => t.toUpperCase());
+    if (normalizedType) {
+        sanitized.type = normalizedType;
+    }
+}
+
+/**
+ * 处理 type 字段（OpenAI 格式）
+ * @param {Object} sanitized - 目标对象
+ * @param {string|Array} typeValue - type 字段值
+ */
+function handleOpenAITypeField(sanitized, typeValue) {
+    if (Array.isArray(typeValue)) {
+        sanitized.type = typeValue.map(t => t.toLowerCase());
+    } else if (typeof typeValue === 'string') {
+        sanitized.type = typeValue.toLowerCase();
+    }
+}
+
+/**
+ * 通用 JSON Schema 清理函数
+ * @param {Object} schema - JSON Schema
+ * @param {Object} options - 清理选项
+ * @param {Array} options.allowedKeys - 允许的键白名单（可选）
+ * @param {Array} options.excludedKeys - 排除的键黑名单（可选）
+ * @param {Function} options.typeHandler - type 字段处理函数
+ * @param {Function} recursiveFn - 递归调用的函数
+ * @returns {Object} 清理后的 JSON Schema
+ */
+function cleanJsonSchemaGeneric(schema, options, recursiveFn) {
+    if (!schema || typeof schema !== 'object') {
+        return schema;
+    }
+
+    if (Array.isArray(schema)) {
+        return schema.map(item => recursiveFn(item));
+    }
+
+    const { allowedKeys, excludedKeys, typeHandler } = options;
+    const sanitized = {};
+
+    for (const [key, value] of Object.entries(schema)) {
+        // 应用黑名单过滤
+        if (excludedKeys && excludedKeys.includes(key)) {
+            continue;
+        }
+
+        // 应用白名单过滤
+        if (allowedKeys && !allowedKeys.includes(key)) {
+            continue;
+        }
+
+        // 处理 properties
+        if (key === 'properties' && typeof value === 'object' && value !== null) {
+            sanitized[key] = cleanPropertiesRecursively(value, recursiveFn);
+            continue;
+        }
+
+        // 处理 items
+        if (key === 'items') {
+            sanitized[key] = recursiveFn(value);
+            continue;
+        }
+
+        // 处理 type
+        if (key === 'type') {
+            typeHandler(sanitized, value);
+            continue;
+        }
+
+        // 其他属性直接复制
+        sanitized[key] = value;
+    }
+
+    return sanitized;
+}
+
 /**
  * 清理JSON Schema属性（移除Gemini不支持的属性）
  * Google Gemini API 只支持有限的 JSON Schema 属性，不支持以下属性：
@@ -190,62 +323,32 @@ export function extractAndProcessSystemMessages(messages, replacements = []) {
  * @returns {Object} 清理后的JSON Schema
  */
 export function cleanJsonSchemaProperties(schema) {
-    if (!schema || typeof schema !== 'object') {
-        return schema;
-    }
+    return cleanJsonSchemaGeneric(
+        schema,
+        {
+            allowedKeys: GEMINI_ALLOWED_KEYS,
+            typeHandler: handleGeminiTypeField
+        },
+        cleanJsonSchemaProperties
+    );
+}
 
-    // 如果是数组，递归处理每个元素
-    if (Array.isArray(schema)) {
-        return schema.map(item => cleanJsonSchemaProperties(item));
-    }
-
-    // Gemini 支持的 JSON Schema 属性白名单
-    const allowedKeys = [
-        "type",
-        "description",
-        "properties",
-        "required",
-        "enum",
-        "items",
-        "nullable"
-    ];
-
-    const sanitized = {};
-    for (const [key, value] of Object.entries(schema)) {
-        if (allowedKeys.includes(key)) {
-            // 对于需要递归处理的属性
-            if (key === 'properties' && typeof value === 'object' && value !== null) {
-                const cleanProperties = {};
-                for (const [propName, propSchema] of Object.entries(value)) {
-                    cleanProperties[propName] = cleanJsonSchemaProperties(propSchema);
-                }
-                sanitized[key] = cleanProperties;
-            } else if (key === 'items') {
-                sanitized[key] = cleanJsonSchemaProperties(value);
-            } else if (key === 'type') {
-                // Google Gemini API 不支持数组形式的 type (如 ["string", "null"])
-                // 必须是单个字符串，且通常需要大写 (STRING, NUMBER, OBJECT, ARRAY, BOOLEAN, INTEGER)
-                if (Array.isArray(value)) {
-                    // 如果包含 null，设置 nullable 为 true
-                    if (value.includes('null')) {
-                        sanitized.nullable = true;
-                    }
-                    // 取第一个非 null 类型
-                    const actualType = value.find(t => t !== 'null');
-                    if (actualType) {
-                        sanitized[key] = actualType.toUpperCase();
-                    }
-                } else if (typeof value === 'string') {
-                    sanitized[key] = value.toUpperCase();
-                }
-            } else {
-                sanitized[key] = value;
-            }
-        }
-        // 其他属性（如 exclusiveMinimum, minimum, maximum, pattern 等）被忽略
-    }
-
-    return sanitized;
+/**
+ * 清理JSON Schema属性（用于OpenAI格式）
+ * OpenAI API 要求标准的 JSON Schema 格式，type 字段必须是小写
+ * 移除不必要的属性：$schema, additionalProperties 等
+ * @param {Object} schema - JSON Schema
+ * @returns {Object} 清理后的JSON Schema
+ */
+export function cleanJsonSchemaForOpenAI(schema) {
+    return cleanJsonSchemaGeneric(
+        schema,
+        {
+            excludedKeys: OPENAI_EXCLUDED_KEYS,
+            typeHandler: handleOpenAITypeField
+        },
+        cleanJsonSchemaForOpenAI
+    );
 }
 
 /**


### PR DESCRIPTION
## 问题

  将 Claude custom 协议转换为 OpenAI 协议时，存在多类兼容性问题：

  ### 1. tool schema 转换错误

  1. **type 字段被错误转为大写** — 原先复用了 Gemini 的 `cleanJsonSchemaProperties`，会将 `type: "string"` 转为
  `"STRING"`，但 OpenAI 要求小写
  2. **nullable 类型信息丢失** — `type: ["string", "null"]` 被压缩为单个 `type: "string"`，OpenAI
  支持数组形式表达 nullable，不应丢弃
  3. **`additionalProperties` 被错误移除** — OpenAI strict mode 要求 `additionalProperties:
  false`，不应将其列入黑名单

  ### 2. thinking 模式下消息转换错误

  4. **`reasoning_content` 字段缺失** — Claude 消息里的 `thinking` 块未映射到 OpenAI 协议的顶层
  `reasoning_content` 字段，导致 DeepSeek / Kimi / SiliconFlow / GLM-4.6 / MiniMax M2 等上游在 thinking 模式 +
  多轮 tool_calls 场景下返回 400：`The reasoning_content in the thinking mode must be passed back to the API.`
  5. **`adaptive` 思考模式不识别** — 仅判断 `thinking.type === "enabled"`，Claude Opus 4.7 等新模型默认使用的
  `adaptive` 模式被整段跳过，`reasoning_effort` 不生成
  6. **`reasoning_effort` 值不被上游接受** — Anthropic 的 effort 有 `max`/`xhigh`/`high`/`medium`/`low` 五档，但
   OpenAI 兼容上游只接受 `low/medium/high`，透传 `xhigh` 报 `literal_error`
  7. **tool_use 检测漏判** — 原代码只检查 `msg.content[0]`，当 `thinking` 块排在 `tool_use`
  前面时会被误判为普通文本消息

  ## 修复

  ### tool schema

  - 新增 `cleanJsonSchemaForOpenAI` 函数，与 Gemini 版本分离，采用不同策略：
    - 使用黑名单（仅排除 `$schema`）而非白名单，保留 OpenAI 支持的所有标准 JSON Schema 属性
    - type 字段转为小写，保留数组形式（如 `["string", "null"]`）
    - `additionalProperties` 原样透传
  - 重构 `cleanJsonSchemaProperties` 为通用架构 `cleanJsonSchemaGeneric`，Gemini 和 OpenAI 各自传入不同配置

  ### thinking 模式

  - 抽取 assistant 消息中的所有 `thinking` 块拼接为 `reasoning_content`，挂在 OpenAI 消息顶层（与
  `content`、`tool_calls` 同级）
  - thinking 启用时强制带 `reasoning_content`
  字段（空字符串兜底，符合上游"字段存在即可"的校验语义，且不污染上下文）
  - 判断条件由 `=== "enabled"` 扩展为同时支持 `"adaptive"`；adaptive 模式下 effort 改从 `output_config.effort`
  读取
  - `reasoning_effort` 收敛：`max` / `xhigh` → `high`，并加白名单 fallback
  - tool_use 检测改用 `.find(b => b.type === "tool_use")`，避免 thinking 块排序导致的漏判

  ## tool schema 转换对比

  |                      | OpenAI（修复后）              | Gemini                  |
  |----------------------|------------------------------|-------------------------|
  | 过滤策略              | 黑名单（仅排除 `$schema`）    | 白名单（仅保留 7 个属性） |
  | type 大小写           | 小写                         | 大写                    |
  | nullable 表达         | `["string", "null"]` 原样保留 | `nullable: true` + 单类型 |
  | additionalProperties | 保留                         | 丢弃                    |

  ## thinking 转换映射

  | Claude 协议                             | OpenAI 协议（修复后）                      |
  |-----------------------------------------|-------------------------------------------|
  | `thinking: {type: "enabled", budget_tokens: N}` | `reasoning_effort: low/medium/high`（按预算推算） |
  | `thinking: {type: "adaptive"}` + `output_config.effort: max` | `reasoning_effort: high`（max/xhigh 收敛） |
  | assistant `content` 中的 `thinking` 块 | assistant 顶层 `reasoning_content` 字段   |
  | 无 thinking 块（历史轮）+ thinking 启用 | `reasoning_content: ""`（空串兜底）       |