### PR TITLE
fix: normalize provider proxy fields on save

### DIFF
--- a/src/ui-modules/provider-api.js
+++ b/src/ui-modules/provider-api.js
@@ -12,6 +12,7 @@ import { generateUUID, createProviderConfig, formatSystemPath, detectProviderFro
 import { broadcastEvent } from './event-broadcast.js';
 import { getRegisteredProviders, getServiceAdapter, invalidateServiceAdapter, serviceInstances } from '../providers/adapter.js';
 import { withFileLock, atomicWriteFile } from '../utils/file-lock.js';
+import { normalizeProviderConfigFields } from '../utils/provider-config-normalizer.js';
 
 
 
@@ -400,7 +401,7 @@ export async function handleDetectProviderModels(req, res, currentConfig, provid
         }
 
         const body = await getRequestBody(req);
-        const draftConfig = filterMaskedData(body?.providerConfig || {});
+        const draftConfig = normalizeProviderConfigFields(filterMaskedData(body?.providerConfig || {}));
 
         const providerPools = loadProviderPools(currentConfig, providerPoolManager);
         const providers = providerPools[providerType] || [];
@@ -503,7 +504,7 @@ async function _handleAddProvider(req, res, currentConfig, providerPoolManager, 
         }
         
         // 过滤掉脱敏字段
-        const filteredConfig = filterMaskedData(providerConfig);
+        const filteredConfig = normalizeProviderConfigFields(filterMaskedData(providerConfig));
         if (usesManagedModelList(providerType)) {
             filteredConfig.supportedModels = normalizeModelIds(filteredConfig.supportedModels);
             filteredConfig.notSupportedModels = [];
@@ -605,7 +606,7 @@ async function _handleUpdateProvider(req, res, currentConfig, providerPoolManage
         const existingProvider = providers[providerIndex];
         
         // 过滤掉传入配置中的脱敏占位符，避免覆盖真实数据
-        const filteredConfig = filterMaskedData(providerConfig);
+        const filteredConfig = normalizeProviderConfigFields(filterMaskedData(providerConfig));
         if (usesManagedModelList(providerType)) {
             filteredConfig.supportedModels = normalizeModelIds(filteredConfig.supportedModels);
             filteredConfig.notSupportedModels = [];

--- a/src/utils/provider-config-normalizer.js
+++ b/src/utils/provider-config-normalizer.js
@@ -1,0 +1,90 @@
+const PROVIDER_STRING_ARRAY_CONFIG_FIELDS = [
+    'DEFAULT_MODEL_PROVIDERS',
+    'PROXY_ENABLED_PROVIDERS',
+    'TLS_SIDECAR_ENABLED_PROVIDERS'
+];
+
+const PROVIDER_BOOLEAN_CONFIG_FIELDS = [
+    'TLS_SIDECAR_ENABLED'
+];
+
+function normalizeStringArrayConfigValue(value) {
+    if (Array.isArray(value)) {
+        return value
+            .filter(item => item !== undefined && item !== null && item !== false)
+            .map(item => String(item).trim())
+            .filter(Boolean);
+    }
+
+    if (value === undefined || value === null || typeof value === 'boolean') {
+        return [];
+    }
+
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (!trimmed) {
+            return [];
+        }
+
+        if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+            try {
+                const parsed = JSON.parse(trimmed);
+                if (Array.isArray(parsed)) {
+                    return normalizeStringArrayConfigValue(parsed);
+                }
+            } catch {
+                // Fall back to comma-separated parsing below.
+            }
+        }
+
+        return trimmed
+            .split(',')
+            .map(item => item.trim())
+            .filter(Boolean);
+    }
+
+    return [];
+}
+
+function normalizeBooleanConfigValue(value) {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+
+    if (typeof value === 'string') {
+        const normalized = value.trim().toLowerCase();
+        if (['true', '1', 'yes', 'on', 'enabled'].includes(normalized)) {
+            return true;
+        }
+        if (['false', '0', 'no', 'off', 'disabled', ''].includes(normalized)) {
+            return false;
+        }
+    }
+
+    return Boolean(value);
+}
+
+/**
+ * Provider edit UI renders unknown provider fields as text inputs. If root-level
+ * proxy/TLS settings are stored on a provider node, arrays and booleans can
+ * round-trip as strings and silently disable proxy routing. Normalize only known
+ * typed fields that are present in the request, without adding new fields.
+ */
+export function normalizeProviderConfigFields(data) {
+    if (!data || typeof data !== 'object' || Array.isArray(data)) return data;
+
+    const result = { ...data };
+    for (const key of PROVIDER_STRING_ARRAY_CONFIG_FIELDS) {
+        if (Object.prototype.hasOwnProperty.call(result, key)) {
+            result[key] = normalizeStringArrayConfigValue(result[key]);
+        }
+    }
+
+    for (const key of PROVIDER_BOOLEAN_CONFIG_FIELDS) {
+        if (Object.prototype.hasOwnProperty.call(result, key)) {
+            result[key] = normalizeBooleanConfigValue(result[key]);
+        }
+    }
+
+    return result;
+}

--- a/tests/provider-config-normalization.test.js
+++ b/tests/provider-config-normalization.test.js
@@ -1,0 +1,49 @@
+import { normalizeProviderConfigFields } from '../src/utils/provider-config-normalizer.js';
+
+describe('normalizeProviderConfigFields', () => {
+    test('normalizes proxy provider lists and TLS boolean values round-tripped through text inputs', () => {
+        const input = {
+            customName: 'Codex OAuth',
+            PROXY_ENABLED_PROVIDERS: 'openai-codex-oauth',
+            TLS_SIDECAR_ENABLED: 'false',
+            TLS_SIDECAR_ENABLED_PROVIDERS: '[]'
+        };
+
+        const normalized = normalizeProviderConfigFields(input);
+
+        expect(normalized).toMatchObject({
+            customName: 'Codex OAuth',
+            PROXY_ENABLED_PROVIDERS: ['openai-codex-oauth'],
+            TLS_SIDECAR_ENABLED: false,
+            TLS_SIDECAR_ENABLED_PROVIDERS: []
+        });
+        expect(input.PROXY_ENABLED_PROVIDERS).toBe('openai-codex-oauth');
+    });
+
+    test('supports comma-separated and JSON array strings for known provider-list fields', () => {
+        const normalized = normalizeProviderConfigFields({
+            DEFAULT_MODEL_PROVIDERS: 'gemini-cli-oauth, openai-codex-oauth',
+            PROXY_ENABLED_PROVIDERS: '["openai-codex-oauth", "gemini-cli-oauth", ""]',
+            TLS_SIDECAR_ENABLED_PROVIDERS: ['openai-codex-oauth', ' ', 'gemini-cli-oauth']
+        });
+
+        expect(normalized.DEFAULT_MODEL_PROVIDERS).toEqual(['gemini-cli-oauth', 'openai-codex-oauth']);
+        expect(normalized.PROXY_ENABLED_PROVIDERS).toEqual(['openai-codex-oauth', 'gemini-cli-oauth']);
+        expect(normalized.TLS_SIDECAR_ENABLED_PROVIDERS).toEqual(['openai-codex-oauth', 'gemini-cli-oauth']);
+    });
+
+    test('normalizes truthy TLS sidecar string values', () => {
+        expect(normalizeProviderConfigFields({ TLS_SIDECAR_ENABLED: 'true' }).TLS_SIDECAR_ENABLED).toBe(true);
+        expect(normalizeProviderConfigFields({ TLS_SIDECAR_ENABLED: '1' }).TLS_SIDECAR_ENABLED).toBe(true);
+        expect(normalizeProviderConfigFields({ TLS_SIDECAR_ENABLED: 'off' }).TLS_SIDECAR_ENABLED).toBe(false);
+    });
+
+    test('does not add typed fields that are absent from provider config', () => {
+        const normalized = normalizeProviderConfigFields({ customName: 'plain provider' });
+
+        expect(normalized).toEqual({ customName: 'plain provider' });
+        expect(normalized).not.toHaveProperty('PROXY_ENABLED_PROVIDERS');
+        expect(normalized).not.toHaveProperty('TLS_SIDECAR_ENABLED');
+        expect(normalized).not.toHaveProperty('TLS_SIDECAR_ENABLED_PROVIDERS');
+    });
+});


### PR DESCRIPTION
## Summary
- Normalize typed provider-node config fields after masked-data filtering for provider add/update and model-detection draft configs.
- Preserve proxy/TLS routing when fields like `PROXY_ENABLED_PROVIDERS`, `TLS_SIDECAR_ENABLED_PROVIDERS`, `DEFAULT_MODEL_PROVIDERS`, and `TLS_SIDECAR_ENABLED` round-trip through the provider edit UI as text strings.
- Add a focused unit test for string, comma-separated, JSON-array, boolean-string, and absent-field cases.

## Why
The provider edit UI renders unknown provider fields as text inputs. If root-level proxy/TLS settings are stored on a provider node, editing that node can save arrays/booleans as strings, e.g. `PROXY_ENABLED_PROVIDERS: "openai-codex-oauth"` and `TLS_SIDECAR_ENABLED: "false"`. `proxy-utils` expects provider lists to be arrays, so this silently disables proxy routing for that node.

## Test
- `npx jest tests/provider-config-normalization.test.js --runInBand`
