### PR TITLE
feat: add Astraflow provider support (global + China endpoints)

### DIFF
--- a/configs/provider_pools.json.example
+++ b/configs/provider_pools.json.example
@@ -1,4 +1,36 @@
 {
+  "openai-astraflow": [
+    {
+      "customName": "Astraflow Global节点",
+      "OPENAI_API_KEY": "sk-astraflow-global-key",
+      "OPENAI_BASE_URL": "https://api-us-ca.umodelverse.ai/v1",
+      "checkModelName": null,
+      "checkHealth": false,
+      "uuid": "a1f39c65-d3c5-41b1-9985-9f6e3d7bastr",
+      "isHealthy": true,
+      "isDisabled": false,
+      "lastUsed": null,
+      "usageCount": 0,
+      "errorCount": 0,
+      "lastErrorTime": null
+    }
+  ],
+  "openai-astraflow-cn": [
+    {
+      "customName": "Astraflow China节点",
+      "OPENAI_API_KEY": "sk-astraflow-china-key",
+      "OPENAI_BASE_URL": "https://api.modelverse.cn/v1",
+      "checkModelName": null,
+      "checkHealth": false,
+      "uuid": "b2f39c65-d3c5-41b1-9985-9f6e3d7bcnst",
+      "isHealthy": true,
+      "isDisabled": false,
+      "lastUsed": null,
+      "usageCount": 0,
+      "errorCount": 0,
+      "lastErrorTime": null
+    }
+  ],
   "openai-custom": [
     {
       "customName": "OpenAI节点1",

--- a/src/providers/provider-models.js
+++ b/src/providers/provider-models.js
@@ -122,6 +122,8 @@ export const PROVIDER_MODELS = {
         'gpt-image-2',
     ],
     'forward-api': [],
+    'openai-astraflow': [],
+    'openai-astraflow-cn': [],
     'grok-web': [
         'grok-4.1-mini',
         'grok-4.1-thinking',

--- a/src/providers/provider-pool-manager.js
+++ b/src/providers/provider-pool-manager.js
@@ -59,6 +59,8 @@ export class ProviderPoolManager {
         'openaiResponses-custom': 'gpt-4o-mini',
         'forward-api': 'gpt-4o-mini',
         'grok-web': 'grok-4.1-mini',
+        'openai-astraflow': 'gpt-4o-mini',
+        'openai-astraflow-cn': 'gpt-4o-mini',
     };
 
     constructor(providerPools, options = {}) {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -67,6 +67,8 @@ export const MODEL_PROVIDER = {
     CODEX_API: 'openai-codex-oauth',
     FORWARD_API: 'forward-api',
     GROK_WEB: 'grok-web',
+    ASTRAFLOW_API: 'openai-astraflow',
+    ASTRAFLOW_CN_API: 'openai-astraflow-cn',
     AUTO: 'auto',
 };
 


### PR DESCRIPTION
## Summary

Adds [Astraflow](https://astraflow.ucloud-global.com) by UCloud as a supported provider. Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models.

Because Astraflow is fully OpenAI-compatible, it reuses the existing `OpenAIApiServiceAdapter` (exactly like `openai-custom`) — no new SDK or adapter class needed. Two named provider types are added for discoverability:

| Provider type | Endpoint | Env key |
|---|---|---|
| `openai-astraflow` | `https://api-us-ca.umodelverse.ai/v1` | `OPENAI_API_KEY` in pool config |
| `openai-astraflow-cn` | `https://api.modelverse.cn/v1` | `OPENAI_API_KEY` in pool config |

API key signup: https://astraflow.ucloud-global.com (global) / https://astraflow.ucloud.cn (China)

## Changes

### `src/utils/constants.js`
- Add `ASTRAFLOW_API: 'openai-astraflow'` and `ASTRAFLOW_CN_API: 'openai-astraflow-cn'` to `MODEL_PROVIDER`

### `src/providers/provider-models.js`
- Add `'openai-astraflow': []` and `'openai-astraflow-cn': []` entries to `PROVIDER_MODELS`
  (empty list — Astraflow dynamically exposes 200+ models via `/models`)

### `src/providers/provider-pool-manager.js`
- Add `'openai-astraflow'` and `'openai-astraflow-cn'` to `DEFAULT_HEALTH_CHECK_MODELS`

### `configs/provider_pools.json.example`
- Add example `openai-astraflow` (global) and `openai-astraflow-cn` (China) pool entries showing how to configure the API key and base URL

## Usage

Add to `configs/provider_pools.json`:

```json
{
  "openai-astraflow": [
    {
      "customName": "Astraflow Global",
      "OPENAI_API_KEY": "your-astraflow-api-key",
      "OPENAI_BASE_URL": "https://api-us-ca.umodelverse.ai/v1",
      "uuid": "...",
      "isHealthy": true,
      "isDisabled": false
    }
  ]
}
```

Then set `"MODEL_PROVIDER": "openai-astraflow"` in `config.json`.
