### PR TITLE
fix: map gemini-3.5-flash-high to gemini-3.5-flash-low upstream

### DIFF
--- a/src/providers/gemini/antigravity-core.js
+++ b/src/providers/gemini/antigravity-core.js
@@ -49,6 +49,7 @@ const ANTIGRAVITY_MODELS = getProviderModels(MODEL_PROVIDER.ANTIGRAVITY);
 const ANTIGRAVITY_CLIENT_TO_UPSTREAM_MODEL = {
     'gemini-3.1-pro-high': 'gemini-pro-agent',
     'gemini-3.1-pro-preview': 'gemini-pro-agent',
+    'gemini-3.5-flash-high': 'gemini-3.5-flash-low',
 };
 
 const ANTIGRAVITY_UPSTREAM_TO_CLIENT_MODELS = {


### PR DESCRIPTION
### 修复内容：
1. 修复 antigravity 中 gemini-3.5-flash-high 模型不可用问题


### 修复说明：
------
经过测试 gemini-3.5-flash-high 实际是 gemini-3.5-flash-low + 上 thinkingLevel = "high" 参数