### PR TITLE
fix: resolve Kiro provider model mapping typo and region fallback

### DIFF
--- a/src/auth/kiro-oauth.js
+++ b/src/auth/kiro-oauth.js
@@ -436,6 +436,7 @@ async function pollKiroBuilderIDToken(clientId, clientSecret, deviceCode, interv
                     authMethod: 'builder-id',
                     clientId,
                     clientSecret,
+                    region: options.region || 'us-east-1',
                     idcRegion: options.region || 'us-east-1'
                 };
                 

--- a/src/providers/claude/claude-kiro.js
+++ b/src/providers/claude/claude-kiro.js
@@ -205,6 +205,7 @@ const KIRO_MODELS = getProviderModels(MODEL_PROVIDER.KIRO_API);
 // 完整的模型映射表
 const FULL_MODEL_MAPPING = {
     "claude-haiku-4-5":"claude-haiku-4.5",
+    "claude-haiku-4-5-20251001":"claude-haiku-4.5",
     "claude-opus-4-8":"claude-opus-4.8",
     "claude-opus-4-7":"claude-opus-4.7",
     "claude-opus-4-6":"claude-opus-4.6",
@@ -722,8 +723,8 @@ async loadCredentials() {
         applyCredential('idcRegion');
 
         if (!this.region) {
-            logger.warn('[Kiro Auth] Region not found in credentials. Using default region us-east-1 for URLs.');
-            this.region = 'us-east-1';
+            this.region = this.idcRegion || 'us-east-1';
+            logger.warn(`[Kiro Auth] Region not found in credentials. Using idcRegion/default: ${this.region}`);
         }
 
         // idcRegion 用于 REFRESH_IDC_URL，如果未设置则使用 region
@@ -2124,7 +2125,7 @@ async saveCredentialsToFile(filePath, newData) {
             this._markCredentialNeedRefresh('Token near expiry in generateContent');
         }
         
-        const finalModel = MODEL_MAPPING[model] ? model : model;
+        const finalModel = MODEL_MAPPING[model] || model;
         logger.info(`[Kiro] Calling generateContent with model: ${finalModel}`);
         
         // Estimate input tokens before making the API call
@@ -2483,7 +2484,7 @@ async saveCredentialsToFile(filePath, newData) {
             this._markCredentialNeedRefresh('Token near expiry in generateContentStream');
         }
         
-        const finalModel = MODEL_MAPPING[model] ? model : model;
+        const finalModel = MODEL_MAPPING[model] || model;
         logger.info(`[Kiro] Calling generateContentStream with model: ${finalModel} (real streaming)`);
 
         let inputTokens = 0;


### PR DESCRIPTION
## Description
This PR addresses two critical authorization and configuration issues within the Kiro provider:

1. **Model Mapping Resolution Bug**: Fixed a logical typo in `claude-kiro.js` where `finalModel` incorrectly evaluated to the original model name instead of the mapped value. This ensures models like `claude-haiku-4-5` are correctly transformed to `claude-haiku-4.5` before being sent to Amazon Q, preventing 403 authorization rejections.

2. **Regional Configuration Fallback**: Fixed an issue where the region would incorrectly fallback to `us-east-1` and ignore the user's `idcRegion`. When users authenticate via AWS Builder ID in regions like `eu-central-1`, the standard `region` key may be omitted in favor of `idcRegion`. This update ensures the token's region is respected, and patches `kiro-oauth.js` to populate the standard `region` field moving forward.

## Changes Made
* `src/providers/claude/claude-kiro.js`: Fixed `MODEL_MAPPING` typo in `generateContent` and `generateContentStream`. Implemented `idcRegion` fallback for `this.region`. Added missing `claude-haiku-4-5-20251001` alias.
* `src/auth/kiro-oauth.js`: Added the `region` field to the saved credentials when using AWS Builder ID tokens.

These fixes resolve recurring `403 Forbidden` API errors and ensure smooth multi-region deployments.