### PR TITLE
fix(usage): 移除用量百分比 100% 上限，支持显示超额百分比

### DIFF
--- a/src/services/usage-service.js
+++ b/src/services/usage-service.js
@@ -292,7 +292,7 @@ export function formatKiroUsage(usageData) {
         if (isWithinWindow(breakdown.nextDateReset)) {
             const used = breakdown.currentUsageWithPrecision ?? breakdown.currentUsage;
             const limit = breakdown.usageLimitWithPrecision ?? breakdown.usageLimit;
-            const percent = limit > 0 ? Math.min(100, (used / limit) * 100) : 0;
+            const percent = limit > 0 ? (used / limit) * 100 : 0;
             
             items.push({
                 id: breakdown.resourceType,
@@ -314,7 +314,7 @@ export function formatKiroUsage(usageData) {
 
                 const bUsed = bonus.currentUsageWithPrecision ?? bonus.currentUsage ?? 0;
                 const bLimit = bonus.usageLimitWithPrecision ?? bonus.usageLimit ?? 0;
-                const bPercent = bLimit > 0 ? Math.min(100, (bUsed / bLimit) * 100) : 0;
+                const bPercent = bLimit > 0 ? (bUsed / bLimit) * 100 : 0;
                 const isExpired = bonus.status === 'EXPIRED';
                 
                 items.push({
@@ -337,7 +337,7 @@ export function formatKiroUsage(usageData) {
             if (isWithinWindow(ft.freeTrialExpiry)) {
                 const ftUsed = ft.currentUsageWithPrecision ?? ft.currentUsage ?? 0;
                 const ftLimit = ft.usageLimitWithPrecision ?? ft.usageLimit ?? 0;
-                const ftPercent = ftLimit > 0 ? Math.min(100, (ftUsed / ftLimit) * 100) : 0;
+                const ftPercent = ftLimit > 0 ? (ftUsed / ftLimit) * 100 : 0;
                 const isExpired = ft.freeTrialStatus === 'EXPIRED';
                 
                 items.push({
@@ -359,7 +359,7 @@ export function formatKiroUsage(usageData) {
     const activeItems = items.filter(item => !item.isExpired);
     const totalUsed = activeItems.reduce((sum, item) => sum + item.used, 0);
     const totalLimit = activeItems.reduce((sum, item) => sum + item.limit, 0);
-    const usedPercent = totalLimit > 0 ? Math.min(100, (totalUsed / totalLimit) * 100) : 0;
+    const usedPercent = totalLimit > 0 ? (totalUsed / totalLimit) * 100 : 0;
 
     // 兼容多种用户信息和计划信息的路径
     let plan = usageData.subscriptionInfo?.subscriptionTitle || 

--- a/static/potluck.html
+++ b/static/potluck.html
@@ -1184,7 +1184,7 @@
                             <div class="label">今日/限额</div>
                             <div class="value ${valueClass}">${key.todayUsage}/${key.dailyLimit}</div>
                             <div class="value muted">${formatTokenCompact(key.todayTotalTokens || 0)} Tokens ${key.todayCachedTokens ? `(含 ${formatTokenCompact(key.todayCachedTokens)} 缓存)` : ''}</div>
-                            <div class="progress-bar"><div class="fill ${progressClass}" style="width:${Math.min(usagePercent, 100)}%"></div></div>
+                            <div class="progress-bar"><div class="fill ${progressClass}" style="width:${usagePercent}%"></div></div>
                         </div>
                         <div class="key-stat">
                             <div class="label">累计数据</div>


### PR DESCRIPTION
将 Kiro 等账户的用量百分比从硬限制 100%（Math.min(100, ...)）改为显示真实百分比，支持显示超额（如 1000%）情况。

有些企业的 Kiro 账号可以**超出 100% 用量，比如超出 10 倍**。硬限制在 100% 无法反映真实使用情况，显示真实百分比让用户能准确了解超额程度。

## Before / After

| Before | After |
|:---:|:---:|
| <img width="366" height="504" alt="image" src="https://github.com/user-attachments/assets/7643ab6f-8f0c-4d8c-b729-0649e49f3909" />  | <img width="378" height="490" alt="image" src="https://github.com/user-attachments/assets/889ee17f-9097-43ed-8d31-a1c4d7354832" /> |

## 修改内容

- `src/services/usage-service.js`：移除 4 处 `Math.min(100, ...)` 限制
- `static/potluck.html`：移除进度条宽度的 `Math.min(usagePercent, 100)` 限制