### PR TITLE
fix(kiro): 修复 kiro opus 4.7+ 流式响应断流问题

### DIFF
--- a/src/providers/claude/claude-kiro.js
+++ b/src/providers/claude/claude-kiro.js
@@ -2424,6 +2424,9 @@ async saveCredentialsToFile(filePath, newData) {
             stream = response.data;
             let buffer = Buffer.alloc(0);
             let lastContentEvent = null;  // 用于检测连续重复的 content 事件
+            // 是否已经向上层产出过内容（content/reasoning/toolUse）。
+            // 一旦产出过，流中途断线就不能从头重发（会导致内容重复/错位）。
+            let hasYieldedContent = false;
 
             for await (const chunk of stream) {
                 const chunkBuf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
@@ -2442,16 +2445,20 @@ async saveCredentialsToFile(filePath, newData) {
                             continue;
                         }
                         lastContentEvent = event.data;
+                        hasYieldedContent = true;
                         yield { type: 'content', content: event.data };
                     } else if (event.type === 'reasoning') {
+                        hasYieldedContent = true;
                         yield { type: 'reasoning', reasoning: event.data };
                     } else if (event.type === 'toolUse') {
+                        hasYieldedContent = true;
                         const toolUse = {
                             ...event.data,
                             name: toolNameMaps?.fromKiroName ? toolNameMaps.fromKiroName(event.data?.name) : event.data?.name
                         };
                         yield { type: 'toolUse', toolUse };
                     } else if (event.type === 'toolUseInput') {
+                        hasYieldedContent = true;
                         yield { type: 'toolUseInput', input: event.data.input };
                     } else if (event.type === 'toolUseStop') {
                         yield { type: 'toolUseStop', stop: event.data.stop };
@@ -2534,13 +2541,18 @@ async saveCredentialsToFile(filePath, newData) {
             }
 
             // Handle network errors (ECONNRESET, ETIMEDOUT, etc.) with exponential backoff
-            if (isNetworkError && retryCount < maxRetries) {
+            // 只在尚未产出任何内容时才从头重试：若已经 yield 过内容，
+            // 从头重发会导致已发送部分与重试响应重复/错位，故中途断线不重试。
+            if (isNetworkError && retryCount < maxRetries && !hasYieldedContent) {
                 const delay = baseDelay * Math.pow(2, retryCount);
                 const errorIdentifier = errorCode || errorMessage.substring(0, 50);
                 logger.info(`[Kiro] Network error (${errorIdentifier}) in stream. Retrying in ${delay}ms... (attempt ${retryCount + 1}/${maxRetries})`);
                 await new Promise(resolve => setTimeout(resolve, delay));
                 yield* this.streamApiReal(method, model, body, isRetry, retryCount + 1);
                 return;
+            }
+            if (isNetworkError && hasYieldedContent) {
+                logger.warn(`[Kiro] Network error (${errorCode || 'stream'}) after content already sent; not retrying to avoid duplication. Ending stream.`);
             }
 
             if (error.response && error.response.data) {

--- a/src/providers/claude/claude-kiro.js
+++ b/src/providers/claude/claude-kiro.js
@@ -2240,134 +2240,139 @@ async saveCredentialsToFile(filePath, newData) {
     }
 
     /**
-     * 解析 AWS Event Stream 格式，提取所有完整的 JSON 事件
-     * 返回 { events: 解析出的事件数组, remaining: 未处理完的缓冲区 }
+     * 按 AWS Event Stream 标准帧格式解析（基于 Buffer）。
+     * 帧格式: [4B totalLen][4B headersLen][4B preludeCRC][headers][payload][4B msgCRC]
+     * 相比旧的 indexOf('{') shape-based 解析，这里按 totalLen 精确切帧，
+     * 不会被帧头二进制里的 { 字节误导，彻底解决分片边界导致的卡死。
+     * 输入 buffer 为 Buffer；返回 { events, remaining:Buffer }，events 格式与旧解析器一致。
      */
     parseAwsEventStreamBuffer(buffer) {
         const events = [];
-        let remaining = buffer;
-        let searchStart = 0;
-        
+        let offset = 0;
+
         while (true) {
-            // 查找真正的 JSON payload 起始位置。AWS Event Stream 包含二进制头部，
-            // payload 对象里的 key 顺序不稳定，所以不能依赖 {"input": 这类固定开头。
-            const jsonStart = remaining.indexOf('{', searchStart);
-            if (jsonStart < 0) break;
-            
-            // 正确处理嵌套的 {} - 使用括号计数法
-            let braceCount = 0;
-            let jsonEnd = -1;
-            let inString = false;
-            let escapeNext = false;
-            
-            for (let i = jsonStart; i < remaining.length; i++) {
-                const char = remaining[i];
-                
-                if (escapeNext) {
-                    escapeNext = false;
-                    continue;
-                }
-                
-                if (char === '\\') {
-                    escapeNext = true;
-                    continue;
-                }
-                
-                if (char === '"') {
-                    inString = !inString;
-                    continue;
-                }
-                
-                if (!inString) {
-                    if (char === '{') {
-                        braceCount++;
-                    } else if (char === '}') {
-                        braceCount--;
-                        if (braceCount === 0) {
-                            jsonEnd = i;
-                            break;
-                        }
-                    }
-                }
-            }
-            
-            if (jsonEnd < 0) {
-                // 不完整的 JSON，保留在缓冲区等待更多数据
-                remaining = remaining.substring(jsonStart);
-                break;
-            }
-            
-            const jsonStr = remaining.substring(jsonStart, jsonEnd + 1);
-            try {
-                const parsed = JSON.parse(jsonStr);
-                // 处理 content 事件
-                if (parsed.content !== undefined && !parsed.followupPrompt) {
-                    // 处理转义字符
-                    let decodedContent = parsed.content;
-                    // 无须处理转义的换行符，原来要处理是因为智能体返回的 content 需要通过换行符切割不同的json
-                    // decodedContent = decodedContent.replace(/(?<!\\)\\n/g, '\n');
-                    events.push({ type: 'content', data: decodedContent });
-                }
-                // 处理结构化工具调用事件 - 开始事件（包含 name 和 toolUseId）
-                else if (parsed.name && parsed.toolUseId) {
-                    events.push({ 
-                        type: 'toolUse', 
-                        data: {
-                            name: parsed.name,
-                            toolUseId: parsed.toolUseId,
-                            input: normalizeKiroToolInput(parsed.input),
-                            stop: parsed.stop || false
-                        }
-                    });
-                }
-                // 处理工具调用的 input 续传事件（可能包含 toolUseId，且 key 顺序不固定）
-                else if (parsed.input !== undefined && !parsed.name) {
-                    events.push({
-                        type: 'toolUseInput',
-                        data: {
-                            toolUseId: parsed.toolUseId,
-                            input: normalizeKiroToolInput(parsed.input)
-                        }
-                    });
-                }
-                // 处理工具调用的结束事件（只有 stop 字段，且不包含 contextUsagePercentage）
-                else if (parsed.stop !== undefined && parsed.contextUsagePercentage === undefined) {
-                    events.push({
-                        type: 'toolUseStop',
-                        data: {
-                            stop: parsed.stop
-                        }
-                    });
-                }
-                // 处理上下文使用百分比事件（最后一条消息）
-                else if (parsed.contextUsagePercentage !== undefined) {
-                    events.push({
-                        type: 'contextUsage',
-                        data: {
-                            contextUsagePercentage: parsed.contextUsagePercentage
-                        }
-                    });
-                }
-            } catch (e) {
-                // JSON 解析失败，跳过这个 "{" 继续搜索，避免二进制头部中的偶然字符阻塞后续 payload
-                searchStart = jsonStart + 1;
+            // 不足一个 prelude(12B)
+            if (buffer.length - offset < 12) break;
+
+            const totalLen = buffer.readUInt32BE(offset);
+            const headersLen = buffer.readUInt32BE(offset + 4);
+
+            // 帧头合法性检查：非法则丢一字节重新同步（容错）
+            if (totalLen < 16 || totalLen > 16 * 1024 * 1024 ||
+                headersLen > totalLen - 16) {
+                offset += 1;
                 continue;
             }
-            
-            searchStart = jsonEnd + 1;
-            if (searchStart >= remaining.length) {
-                remaining = '';
-                break;
+
+            // 整帧未到齐，等下一个 chunk（处理分片）
+            if (buffer.length - offset < totalLen) break;
+
+            const frameStart = offset;
+            const headersStart = frameStart + 12;
+            const payloadStart = headersStart + headersLen;
+            const payloadEnd = frameStart + totalLen - 4; // 末4字节是 msg CRC
+
+            // 从帧头读取权威的 :event-type（type-based 分发的依据）
+            const eventType = this._readEventTypeHeader(buffer, headersStart, headersLen);
+            const payloadStr = buffer.slice(payloadStart, payloadEnd).toString('utf8');
+            offset += totalLen; // 消费这一帧
+
+            let parsed;
+            try {
+                parsed = JSON.parse(payloadStr);
+            } catch (e) {
+                // payload 非法 JSON（理论上不应发生），跳过该帧
+                logger.warn('[Kiro] Frame payload not valid JSON, skipped: ' + payloadStr.slice(0, 120));
+                continue;
+            }
+
+            // 事件分类：优先按上游声明的 :event-type 分发（type-based）。
+            switch (eventType) {
+                case 'assistantResponseEvent':
+                    if (parsed.content !== undefined && !parsed.followupPrompt) {
+                        events.push({ type: 'content', data: parsed.content });
+                    }
+                    break;
+                case 'reasoningContentEvent':
+                    // 思考流，payload 为 {"text":"..."}
+                    if (parsed.text !== undefined) {
+                        events.push({ type: 'reasoning', data: parsed.text });
+                    }
+                    break;
+                case 'toolUseEvent':
+                    // 工具调用：同一个 event-type 下含开始/续传/结束三种，按 payload 字段区分
+                    if (parsed.name && parsed.toolUseId) {
+                        events.push({
+                            type: 'toolUse',
+                            data: {
+                                name: parsed.name,
+                                toolUseId: parsed.toolUseId,
+                                input: normalizeKiroToolInput(parsed.input),
+                                stop: parsed.stop || false
+                            }
+                        });
+                    } else if (parsed.input !== undefined && !parsed.name) {
+                        events.push({
+                            type: 'toolUseInput',
+                            data: {
+                                toolUseId: parsed.toolUseId,
+                                input: normalizeKiroToolInput(parsed.input)
+                            }
+                        });
+                    } else if (parsed.stop !== undefined) {
+                        events.push({ type: 'toolUseStop', data: { stop: parsed.stop } });
+                    }
+                    break;
+                default:
+                    // 无 event-type 头或未知类型：回退到基于 payload 字段的判断（兼容性兵底）。
+                    if (parsed.contextUsagePercentage !== undefined) {
+                        events.push({ type: 'contextUsage', data: { contextUsagePercentage: parsed.contextUsagePercentage } });
+                    } else if (parsed.content !== undefined && !parsed.followupPrompt) {
+                        events.push({ type: 'content', data: parsed.content });
+                    } else if (parsed.text !== undefined) {
+                        events.push({ type: 'reasoning', data: parsed.text });
+                    } else if (parsed.name && parsed.toolUseId) {
+                        events.push({ type: 'toolUse', data: { name: parsed.name, toolUseId: parsed.toolUseId, input: normalizeKiroToolInput(parsed.input), stop: parsed.stop || false } });
+                    } else if (parsed.input !== undefined && !parsed.name) {
+                        events.push({ type: 'toolUseInput', data: { toolUseId: parsed.toolUseId, input: normalizeKiroToolInput(parsed.input) } });
+                    } else if (parsed.stop !== undefined) {
+                        events.push({ type: 'toolUseStop', data: { stop: parsed.stop } });
+                    }
+                    // {"signature":...} 签名事件、metering 等无内容意义的类型：静默忽略
+                    break;
             }
         }
-        
-        // 如果 searchStart 有进展，截取剩余部分
-        if (searchStart > 0 && remaining.length > 0) {
-            remaining = remaining.substring(searchStart);
-        }
-        
-        return { events, remaining };
+
+        return { events, remaining: buffer.slice(offset) };
     }
+
+    /**
+     * 从 AWS Event Stream 帧的 headers 区读取 :event-type 的值。
+     * header 格式: [1B nameLen][name][1B valueType][...]，string 类型(7) 为 [2B valueLen][value]。
+     * 解析失败或无此头时返回 null（调用方会回退到 payload 字段判断）。
+     */
+    _readEventTypeHeader(buffer, start, headersLen) {
+        try {
+            let p = start;
+            const end = start + headersLen;
+            while (p < end) {
+                const nameLen = buffer.readUInt8(p); p += 1;
+                const name = buffer.slice(p, p + nameLen).toString('utf8'); p += nameLen;
+                const valueType = buffer.readUInt8(p); p += 1;
+                if (valueType === 7) {
+                    // string: [2B len][value]
+                    const valueLen = buffer.readUInt16BE(p); p += 2;
+                    const value = buffer.slice(p, p + valueLen).toString('utf8'); p += valueLen;
+                    if (name === ':event-type') return value;
+                } else {
+                    // 遇到非 string 类型的头（kiro 帧头均为 string），为安全起见中断
+                    break;
+                }
+            }
+        } catch (e) { /* 解析失败回退 */ }
+        return null;
+    }
+
 
     /**
      * 真正的流式 API 调用 - 使用 responseType: 'stream'
@@ -2417,13 +2422,14 @@ async saveCredentialsToFile(filePath, newData) {
             const response = await this.axiosInstance.request(axiosConfig);
 
             stream = response.data;
-            let buffer = '';
+            let buffer = Buffer.alloc(0);
             let lastContentEvent = null;  // 用于检测连续重复的 content 事件
 
             for await (const chunk of stream) {
-                buffer += chunk.toString();
+                const chunkBuf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+                buffer = buffer.length === 0 ? chunkBuf : Buffer.concat([buffer, chunkBuf]);
                 
-                // 解析缓冲区中的事件
+                // 按 AWS 标准帧格式解析缓冲区中的事件
                 const { events, remaining } = this.parseAwsEventStreamBuffer(buffer);
                 buffer = remaining;
                 
@@ -2437,6 +2443,8 @@ async saveCredentialsToFile(filePath, newData) {
                         }
                         lastContentEvent = event.data;
                         yield { type: 'content', content: event.data };
+                    } else if (event.type === 'reasoning') {
+                        yield { type: 'reasoning', reasoning: event.data };
                     } else if (event.type === 'toolUse') {
                         const toolUse = {
                             ...event.data,
@@ -2714,6 +2722,12 @@ async saveCredentialsToFile(filePath, newData) {
                 if (event.type === 'contextUsage' && event.contextUsagePercentage) {
                     // 捕获上下文使用百分比（包含输入和输出的总使用量）
                     contextUsagePercentage = event.contextUsagePercentage;
+                } else if (event.type === 'reasoning' && event.reasoning) {
+                    // 原生 reasoning 流（reasoningContentEvent）：直接走 thinking 输出通道，
+                    // 不经过 <thinking> 标签扫描（新模型的思考不再内联在 content 标签里）。
+                    totalContent += event.reasoning;
+                    yield* pushEvents(createThinkingDeltaEvents(event.reasoning));
+                    continue;
                 } else if (event.type === 'content' && event.content) {
                     totalContent += event.content;
 

--- a/src/providers/claude/claude-kiro.js
+++ b/src/providers/claude/claude-kiro.js
@@ -198,6 +198,9 @@ function normalizeKiroToolInput(input) {
 
 // Per-model context window sizes for accurate token estimation
 const MODEL_CONTEXT_TOKENS = {
+    "gpt-5.6-sol": 1000000,
+    "gpt-5.6-terra": 1000000,
+    "gpt-5.6-luna": 1000000,
     "claude-sonnet-5": 1000000,
     "claude-opus-4-8": 1000000,
     "claude-opus-4-7": 1000000,
@@ -249,6 +252,9 @@ const KIRO_MODELS = getProviderModels(MODEL_PROVIDER.KIRO_API);
 
 // 完整的模型映射表
 const FULL_MODEL_MAPPING = {
+    "gpt-5.6-sol":"gpt-5.6-sol",
+    "gpt-5.6-terra":"gpt-5.6-terra",
+    "gpt-5.6-luna":"gpt-5.6-luna",
     "claude-haiku-4-5":"claude-haiku-4.5",
     "claude-haiku-4-5-20251001":"claude-haiku-4.5",
     "claude-sonnet-5":"claude-sonnet-5",

--- a/src/providers/provider-models.js
+++ b/src/providers/provider-models.js
@@ -66,6 +66,9 @@ export const PROVIDER_MODELS = {
     ],
     'claude-custom': [],
     'claude-kiro-oauth': [
+        'gpt-5.6-sol',
+        'gpt-5.6-terra',
+        'gpt-5.6-luna',
         'claude-haiku-4-5',
         'claude-haiku-4-5-20251001',
         'claude-sonnet-5',


### PR DESCRIPTION
问题原因：
opus 4.7/4.8 新增独立的 reasoningContentEvent（payload 为 {"text":"..."}） 代表思考模块，而非旧模型那样内联在 content 文本的 <thinking> 标签里。
[修复 kiro 空响应 情况，增加重试机制](https://github.com/justlovemaki/AIClient2API/pull/661)无法完成解决，仍会存在断流情况

现象1：原解析器 parseAwsEventStreamBuffer 基于 indexOf('{') 的 shape-based 切分， 会被 AWS Event Stream 帧头二进制中的 { 字节误导、在分片边界处错误切帧，导致断流。 
现象2：无法识别 reasoning 事件，在纯思考响应时解析为空并触发空流中断。

解决方案：
1. 改为按 AWS Event Stream 标准帧格式解析，避免 shape-based 切分异常；
2. reasoning 流经由独立事件类型走 thinking 输出通道呈现，纯思考响应不再被判空。