### PR TITLE
fix(antigravity): 为原生Gemini协议客户端补全private tool_use id字段

### DIFF
--- a/src/providers/gemini/antigravity-core.js
+++ b/src/providers/gemini/antigravity-core.js
@@ -422,6 +422,52 @@ function normalizeAntigravityThinking(modelName, payload, isClaudeModel) {
     return payload;
 }
 
+
+// --- [FIX tool_use.id] 为原生 Gemini 协议客户端(如 pi coding agent)补 antigravity 私有 id 字段 ---
+// 走原生 Gemini 协议端点(/v1beta/models/...:generateContent)的客户端(如 pi)遵循标准 Gemini API,
+// 不知道要在 functionCall/functionResponse part 里携带 antigravity 私有扩展字段 id,
+// 导致 Google 后端把这段 Gemini 格式 contents 转成 Claude 的 Anthropic messages 格式时报
+// `messages.N.content.M.tool_use.id: Field required` (400),客户端表现为收到空响应。
+// 注意:这跟 #652(ClaudeConverter.js / OpenAIConverter.js 的 id 回填)是两条不同路径——
+// #652 修的是"客户端发 Claude/OpenAI 格式请求,代理转成 Gemini 格式再转发"这条路径;
+// 这里修的是"客户端本来就发原生 Gemini 格式请求"这条路径,#652 未覆盖。
+const TOOL_ID_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+function generateSyntheticToolId() {
+    const bytes = crypto.randomBytes(26);
+    let s = '';
+    for (let i = 0; i < 26; i++) s += TOOL_ID_ALPHABET[bytes[i] % 62];
+    return 'toolu_vrtx_' + s;
+}
+
+// 遍历 contents,为缺失 id 的 functionCall 生成 synthetic id,
+// 并按 name 做 FIFO 配对,把同一 id 补到对应的 functionResponse 上。
+// 纯请求体内闭环处理,不依赖跨请求状态。
+function ensureToolCallIds(contents) {
+    if (!Array.isArray(contents)) return;
+    const pendingByName = new Map(); // name -> [id, ...] (FIFO)
+    for (const content of contents) {
+        if (!content || !Array.isArray(content.parts)) continue;
+        for (const part of content.parts) {
+            if (!part) continue;
+            if (part.functionCall) {
+                const fc = part.functionCall;
+                if (!fc.id) fc.id = generateSyntheticToolId();
+                if (fc.name) {
+                    if (!pendingByName.has(fc.name)) pendingByName.set(fc.name, []);
+                    pendingByName.get(fc.name).push(fc.id);
+                }
+            } else if (part.functionResponse) {
+                const fr = part.functionResponse;
+                if (!fr.id && fr.name) {
+                    const q = pendingByName.get(fr.name);
+                    if (q && q.length) fr.id = q.shift();
+                }
+            }
+        }
+    }
+}
+// --- [FIX tool_use.id] end ---
+
 /**
  * 将 Gemini 格式请求转换为 Antigravity 格式
  * @param {string} modelName - 模型名称
@@ -432,6 +478,8 @@ function normalizeAntigravityThinking(modelName, payload, isClaudeModel) {
 function geminiToAntigravity(modelName, payload, projectId) {
     // 深拷贝请求体,避免修改原始对象
     let template = JSON.parse(JSON.stringify(payload));
+    // [FIX tool_use.id] 补全 functionCall/functionResponse 的私有 id(原生 Gemini 协议客户端场景)
+    ensureToolCallIds(template.request && template.request.contents);
 
     const isClaudeModel = isClaude(modelName);
     const isImgModel = isImageModel(modelName);


### PR DESCRIPTION
## 问题

走原生 Gemini 协议端点（`/v1beta/models/...:generateContent`）访问 `gemini-claude-*` 系列模型的客户端（如 [pi coding agent](https://github.com/earendil-works/pi-coding-agent)），只要真的走一次 `tool_use` → `tool_result` 往返，之后模型该总结结果的那轮请求就会收到空响应（HTTP 200，但 0 token，`finishReason: stop`），代理没有把上游的错误暴露出来。

抓取上游真实报错定位到根因：

```json
{
  "error": {
    "code": 400,
    "message": "{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"messages.1.content.0.tool_use.id: Field required\"},\"request_id\":\"req_vrtx_...\"}",
    "status": "INVALID_ARGUMENT"
  }
}
```

原因：标准 Gemini API 的 `functionCall`/`functionResponse` part 没有 `id` 字段，走原生 Gemini 协议的客户端自然不会携带它。但 Google 的 Antigravity 内部接口在把这段 Gemini 格式 `contents` 转成 Claude 的 Anthropic `messages` 格式时，要求 `tool_use`/`tool_result` 必须带 `id`，缺失就直接 400。

## 和 #652 的关系

#652（`fix: tool_use.id`）修的是 `ClaudeConverter.js`/`OpenAIConverter.js`——也就是"客户端发 Claude 或 OpenAI 格式请求，代理内部转成 Gemini 格式再转发"这条路径。

本 PR 修的是另一条路径：**客户端本来就直接发原生 Gemini 格式请求**（`antigravity-core.js` 的 `geminiToAntigravity()`），这个函数此前对 `contents/parts` 完全原样透传，没有做任何 id 补全，#652 没有覆盖到这里。两个修复互不重叠。

## 修复

`ensureToolCallIds()` 在请求转发前遍历 `contents`，按 `name` 对 `functionCall`/`functionResponse` 做 FIFO 配对，缺失 `id` 的一律生成 synthetic id 补全并保证两边一致。纯请求体内闭环处理，不依赖跨请求 session 状态，不改变任何其他行为。

## 复现 & 验证

复现命令（自建部署 + pi 环境下 100% 必现）：

```bash
pi -p --provider <antigravity-gemini-provider> --model gemini-claude-sonnet-4-6 \
  --no-session "请用 ls 工具列出当前目录文件，然后告诉我有几个文件"
```

- 修复前：sonnet / opus 均 100% 空响应（多次不同工具验证：`ls`、`bash`）
- 修复后：sonnet ×2、opus ×1 全部正常返回内容，代理日志确认无新增 400
- 同代理下原生 Gemini 模型（如 `gemini-3.6-flash`）全程不受影响（本来就正常，印证问题只存在于 Claude 家族的 Gemini→Anthropic 转换路径）

## 相关

- 同类公开问题：[lbjlaq/Antigravity-Manager#1499](https://github.com/lbjlaq/Antigravity-Manager/issues/1499)（OpenCode / GitHub Copilot / Claude Code 官方 VS Code 插件三个独立客户端，走 Gemini protocol 访问 claude 时报同样的 `tool_use.id: Field required`，但那边走的是 `@ai-sdk/google` 转发路径，跟本 PR 场景不同，仅作为"这是普遍问题"的佐证）
