### PR TITLE
fix(kiro): prevent expired token refresh stalls

### DIFF
--- a/src/providers/claude/claude-kiro.js
+++ b/src/providers/claude/claude-kiro.js
@@ -670,6 +670,7 @@ export class KiroApiService {
         this.modelName = KIRO_CONSTANTS.DEFAULT_MODEL_NAME;
         this.axiosInstance = null; // Initialize later in async method
         this.axiosSocialRefreshInstance = null;
+        this._tokenRefreshPromise = null;
     }
  
     async initialize() {
@@ -846,22 +847,40 @@ async initializeAuth(forceRefresh = false) {
         return;
     }
 
-    // 首先执行基础凭证加载
-    await this.loadCredentials();
-
-    // 只有在明确要求强制刷新，或者 AccessToken 确实缺失时，才执行刷新
-    // 注意：在 V2 架构下，此方法主要由 PoolManager 的后台队列调用
-    if (forceRefresh || (!this.accessToken && this.refreshToken)) {
-        if (!this.refreshToken) {
-            throw new Error('No refresh token available to refresh access token.');
-        }
-
-        const tokenFilePath = this.credsFilePath || path.join(this.credPath, KIRO_AUTH_TOKEN_FILE);
-        await this._doTokenRefresh(this.saveCredentialsToFile.bind(this), tokenFilePath);
+    if (this._tokenRefreshPromise) {
+        await this._tokenRefreshPromise;
+        return;
     }
 
-    if (!this.accessToken) {
-        throw new Error('No access token available after initialization and refresh attempts.');
+    const authOperation = (async () => {
+        // Credential loading belongs to the single-flight operation. Otherwise,
+        // a concurrent caller can reload an expired token while refresh is
+        // writing the new token and overwrite the fresh in-memory value.
+        await this.loadCredentials();
+
+        // 只有在明确要求强制刷新，或者 AccessToken 确实缺失时，才执行刷新
+        // 注意：在 V2 架构下，此方法主要由 PoolManager 的后台队列调用
+        if (forceRefresh || (!this.accessToken && this.refreshToken)) {
+            if (!this.refreshToken) {
+                throw new Error('No refresh token available to refresh access token.');
+            }
+
+            const tokenFilePath = this.credsFilePath || path.join(this.credPath, KIRO_AUTH_TOKEN_FILE);
+            await this._doTokenRefresh(this.saveCredentialsToFile.bind(this), tokenFilePath);
+        }
+
+        if (!this.accessToken) {
+            throw new Error('No access token available after initialization and refresh attempts.');
+        }
+    })();
+
+    this._tokenRefreshPromise = authOperation;
+    try {
+        await authOperation;
+    } finally {
+        if (this._tokenRefreshPromise === authOperation) {
+            this._tokenRefreshPromise = null;
+        }
     }
 }
 
@@ -2228,11 +2247,7 @@ async saveCredentialsToFile(filePath, newData) {
             delete requestBody._requestBaseUrl;
         }
         
-        // 检查 token 是否即将过期，如果是则推送到刷新队列
-        if (this.isExpiryDateNear()) {
-            logger.info('[Kiro] Token is near expiry, marking credential as need refresh...');
-            this._markCredentialNeedRefresh('Token near expiry in generateContent');
-        }
+        await this._prepareAccessTokenForRequest('generateContent');
         
         const finalModel = resolveKiroModel(model, this.config);
         logger.info(`[Kiro] Calling generateContent with model: ${finalModel}`);
@@ -2624,11 +2639,7 @@ async saveCredentialsToFile(filePath, newData) {
             delete requestBody._requestBaseUrl;
         }
         
-        // 检查 token 是否即将过期，如果是则推送到刷新队列
-        if (this.isExpiryDateNear()) {
-            logger.info('[Kiro] Token is near expiry, marking credential as need refresh...');
-            this._markCredentialNeedRefresh('Token near expiry in generateContentStream');
-        }
+        await this._prepareAccessTokenForRequest('generateContentStream');
         
         const finalModel = resolveKiroModel(model, this.config);
         logger.info(`[Kiro] Calling generateContentStream with model: ${finalModel} (real streaming)`);
@@ -3458,13 +3469,28 @@ async saveCredentialsToFile(filePath, newData) {
         try {
             if (!this.expiresAt) return true;
             const expirationTime = new Date(this.expiresAt);
+            const expirationMs = expirationTime.getTime();
+            if (!Number.isFinite(expirationMs)) return true;
             const currentTime = new Date();
             // 给 30 秒缓冲，避免请求过程中过期
             const bufferMs = 30 * 1000;
-            return expirationTime.getTime() <= (currentTime.getTime() + bufferMs);
+            return expirationMs <= (currentTime.getTime() + bufferMs);
         } catch (error) {
             logger.error(`[Kiro] Error checking token expiry: ${error.message}`);
             return true; // Treat as expired if parsing fails
+        }
+    }
+
+    async _prepareAccessTokenForRequest(context) {
+        if (this.isTokenExpired()) {
+            logger.info(`[Kiro] Token expired before ${context}, refreshing synchronously...`);
+            await this.initializeAuth(true);
+            return;
+        }
+
+        if (this.isExpiryDateNear()) {
+            logger.info('[Kiro] Token is near expiry, marking credential as need refresh...');
+            this._markCredentialNeedRefresh(`Token near expiry in ${context}`);
         }
     }
 

--- a/src/providers/provider-pool-manager.js
+++ b/src/providers/provider-pool-manager.js
@@ -352,13 +352,13 @@ export class ProviderPoolManager {
         if (!this.refreshQueues[providerType]) {
             this.refreshQueues[providerType] = {
                 activeCount: 0,
-                waitingTasks: []
+                waitingTasks: [],
+                ownsGlobalSlot: false,
+                waitingForGlobalSlot: false
             };
         }
 
         const queue = this.refreshQueues[providerType];
-        // 记录此任务是否持有一个全局槽位（情况1追加的任务不持有）
-        let ownsGlobalSlot = false;
 
         const runTask = async () => {
             try {
@@ -383,6 +383,9 @@ export class ProviderPoolManager {
                         this._log('error', `Failed to execute next task for ${providerType}: ${err.message}`);
                     });
                 } else if (currentQueue.activeCount === 0) {
+                    const ownsGlobalSlot = currentQueue.ownsGlobalSlot;
+                    currentQueue.ownsGlobalSlot = false;
+
                     // 清理空队列：无论是否持有全局槽位，都应删除已无任务的队列对象
                     if (currentQueue.waitingTasks.length === 0 &&
                         this.refreshQueues[providerType] === currentQueue) {
@@ -391,7 +394,7 @@ export class ProviderPoolManager {
 
                     // 只有持有全局槽位的任务才能递减计数器
                     if (ownsGlobalSlot) {
-                        this.activeProviderRefreshes--;
+                        this.activeProviderRefreshes = Math.max(0, this.activeProviderRefreshes - 1);
                     }
 
                     // 3. 尝试启动下一个等待中的提供商队列
@@ -406,40 +409,51 @@ export class ProviderPoolManager {
         };
 
         const tryStartProviderQueue = () => {
-            if (queue.activeCount < this.refreshConcurrency.perProvider) {
-                queue.activeCount++;
+            const currentQueue = this.refreshQueues[providerType];
+            if (!currentQueue) return;
+
+            if (currentQueue.activeCount < this.refreshConcurrency.perProvider) {
+                currentQueue.activeCount++;
                 runTask().catch(err => {
                     this._log('error', `Critical error in runTask for ${providerType}: ${err.message}`);
                 });
             } else {
-                queue.waitingTasks.push(runTask);
+                currentQueue.waitingTasks.push(runTask);
             }
         };
 
         // 检查全局并发限制（按提供商分组）
         // 情况1: 该提供商已经在运行，直接加入其队列（不占用新的全局槽位）
-        const isExistingQueue = this.refreshQueues[providerType].activeCount > 0 || this.refreshQueues[providerType].waitingTasks.length > 0;
-        if (isExistingQueue) {
+        if (queue.ownsGlobalSlot) {
             tryStartProviderQueue();
         }
-        // 情况2: 该提供商未运行，需要检查全局槽位，此路径持有全局槽位
+        // 情况2: 该提供商正在等待全局槽位，后续任务只加入队列
+        else if (queue.waitingForGlobalSlot) {
+            queue.waitingTasks.push(runTask);
+        }
+        // 情况3: 该提供商未运行，需要检查全局槽位，此路径持有全局槽位
         else if (this.activeProviderRefreshes < this.refreshConcurrency.global) {
-            ownsGlobalSlot = true;
+            queue.ownsGlobalSlot = true;
             this.activeProviderRefreshes++;
             tryStartProviderQueue();
         }
-        // 情况3: 全局槽位已满，进入等待队列，由等待回调负责标记持槽
+        // 情况4: 全局槽位已满，进入等待队列，由等待回调负责标记持槽
         else {
+            queue.waitingForGlobalSlot = true;
             this.globalRefreshWaiters.push(() => {
                 // 重新获取最新的队列引用
                 if (!this.refreshQueues[providerType]) {
                     this.refreshQueues[providerType] = {
                         activeCount: 0,
-                        waitingTasks: []
+                        waitingTasks: [],
+                        ownsGlobalSlot: false,
+                        waitingForGlobalSlot: false
                     };
                 }
                 // 从等待队列启动时持有全局槽位
-                ownsGlobalSlot = true;
+                const currentQueue = this.refreshQueues[providerType];
+                currentQueue.waitingForGlobalSlot = false;
+                currentQueue.ownsGlobalSlot = true;
                 this.activeProviderRefreshes++;
                 tryStartProviderQueue();
             });
@@ -2391,4 +2405,3 @@ export class ProviderPoolManager {
     }
 
 }
-

--- a/tests/kiro-token-refresh.test.js
+++ b/tests/kiro-token-refresh.test.js
@@ -1,0 +1,221 @@
+import { beforeAll, beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+jest.mock('../src/providers/adapter.js', () => ({
+    getServiceAdapter: jest.fn(),
+    getRegisteredProviders: jest.fn(() => []),
+    invalidateServiceAdapter: jest.fn()
+}));
+
+jest.mock('../src/convert/convert.js', () => ({
+    convertData: jest.fn()
+}));
+
+jest.mock('../src/providers/provider-models.js', () => ({
+    getConfiguredSupportedModels: jest.fn(() => []),
+    getCustomModelListProvider: jest.fn(),
+    getProviderModels: jest.fn(() => []),
+    normalizeModelIds: jest.fn(models => models)
+}));
+
+jest.mock('../src/utils/proxy-utils.js', () => ({
+    configureAxiosProxy: jest.fn(),
+    configureTLSSidecar: jest.fn(),
+    isTLSSidecarEnabledForProvider: jest.fn(() => false)
+}));
+
+jest.mock('../src/services/service-manager.js', () => ({
+    getProviderPoolManager: jest.fn(() => null)
+}));
+
+let KiroApiService;
+let ProviderPoolManager;
+
+beforeAll(async () => {
+    ({ KiroApiService } = await import('../src/providers/claude/claude-kiro.js'));
+    ({ ProviderPoolManager } = await import('../src/providers/provider-pool-manager.js'));
+});
+
+function createInitializedService() {
+    const service = new KiroApiService({ uuid: 'test-credential' });
+    service.isInitialized = true;
+    service._markCredentialNeedRefresh = jest.fn();
+    return service;
+}
+
+describe('Kiro access token refresh before requests', () => {
+    let service;
+
+    beforeEach(() => {
+        service = createInitializedService();
+    });
+
+    test('waits for an expired token refresh before a non-streaming request', async () => {
+        const order = [];
+        service.expiresAt = new Date(Date.now() - 60_000).toISOString();
+        service.initializeAuth = jest.fn(async () => {
+            order.push('refresh');
+            service.expiresAt = new Date(Date.now() + 60 * 60_000).toISOString();
+        });
+        service.estimateInputTokens = jest.fn(() => 1);
+        service.callApi = jest.fn(async () => {
+            order.push('request');
+            return {};
+        });
+        service._processApiResponse = jest.fn(() => ({
+            responseText: 'ok',
+            toolCalls: []
+        }));
+
+        await service.generateContent('claude-sonnet-4-5', {});
+
+        expect(order).toEqual(['refresh', 'request']);
+        expect(service.initializeAuth).toHaveBeenCalledWith(true);
+        expect(service._markCredentialNeedRefresh).not.toHaveBeenCalled();
+    });
+
+    test('waits for an expired token refresh before starting a stream', async () => {
+        const order = [];
+        let releaseRefresh;
+        const refreshFinished = new Promise(resolve => {
+            releaseRefresh = resolve;
+        });
+
+        service.expiresAt = new Date(Date.now() - 60_000).toISOString();
+        service.initializeAuth = jest.fn(async () => {
+            order.push('refresh');
+            await refreshFinished;
+        });
+        service.estimateInputTokens = jest.fn(() => 1);
+        service.streamApiReal = jest.fn(async function* () {
+            order.push('request');
+            yield { type: 'content', content: 'ok' };
+        });
+
+        const stream = service._generateContentStreamRaw('claude-sonnet-4-5', {});
+        const firstEventPromise = stream.next();
+        await Promise.resolve();
+
+        expect(order).toEqual(['refresh']);
+        expect(service.streamApiReal).not.toHaveBeenCalled();
+
+        releaseRefresh();
+        const firstEvent = await firstEventPromise;
+        expect(firstEvent.value.type).toBe('message_start');
+
+        await stream.next();
+        expect(order).toEqual(['refresh', 'request']);
+    });
+
+    test('keeps near-expiry tokens on the non-blocking background path', async () => {
+        service.expiresAt = new Date(Date.now() + 5 * 60_000).toISOString();
+        service.initializeAuth = jest.fn();
+
+        await service._prepareAccessTokenForRequest('generateContentStream');
+
+        expect(service.initializeAuth).not.toHaveBeenCalled();
+        expect(service._markCredentialNeedRefresh).toHaveBeenCalledWith(
+            'Token near expiry in generateContentStream'
+        );
+    });
+
+    test('coalesces concurrent forced refreshes for the same credential', async () => {
+        let releaseRefresh;
+        const refreshFinished = new Promise(resolve => {
+            releaseRefresh = resolve;
+        });
+
+        service.accessToken = 'expired-access-token';
+        service.refreshToken = 'refresh-token';
+        service.loadCredentials = jest.fn();
+        service._doTokenRefresh = jest.fn(async () => {
+            await refreshFinished;
+        });
+
+        const firstRefresh = service.initializeAuth(true);
+        const secondRefresh = service.initializeAuth(true);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(service._doTokenRefresh).toHaveBeenCalledTimes(1);
+
+        releaseRefresh();
+        await Promise.all([firstRefresh, secondRefresh]);
+        expect(service._tokenRefreshPromise).toBeNull();
+    });
+
+    test('joins an in-flight refresh before reloading credentials', async () => {
+        let signalRefreshStarted;
+        let releaseRefresh;
+        const refreshStarted = new Promise(resolve => {
+            signalRefreshStarted = resolve;
+        });
+        const refreshFinished = new Promise(resolve => {
+            releaseRefresh = resolve;
+        });
+
+        service.accessToken = 'expired-access-token';
+        service.refreshToken = 'refresh-token';
+        let loadCount = 0;
+        service.loadCredentials = jest.fn(async () => {
+            loadCount++;
+            if (loadCount > 1) {
+                service.accessToken = 'stale-token-reloaded-from-disk';
+            }
+        });
+        service._doTokenRefresh = jest.fn(async () => {
+            service.accessToken = 'fresh-access-token';
+            signalRefreshStarted();
+            await refreshFinished;
+        });
+
+        const firstRefresh = service.initializeAuth(true);
+        await refreshStarted;
+        const secondRefresh = service.initializeAuth(true);
+        await Promise.resolve();
+
+        expect(service.loadCredentials).toHaveBeenCalledTimes(1);
+        expect(service.accessToken).toBe('fresh-access-token');
+
+        releaseRefresh();
+        await Promise.all([firstRefresh, secondRefresh]);
+        expect(service.accessToken).toBe('fresh-access-token');
+    });
+
+    test('treats an invalid expiry timestamp as expired', () => {
+        service.expiresAt = 'not-a-date';
+
+        expect(service.isTokenExpired()).toBe(true);
+    });
+});
+
+describe('Provider refresh queue slots', () => {
+    test('releases the global slot after queued tasks for one provider finish', async () => {
+        const manager = new ProviderPoolManager({}, {
+            globalConfig: {
+                REFRESH_CONCURRENCY_GLOBAL: 1,
+                REFRESH_CONCURRENCY_PER_PROVIDER: 1
+            }
+        });
+        manager._refreshNodeToken = jest.fn(async () => {});
+
+        const first = {
+            uuid: 'first',
+            config: { uuid: 'first', isDisabled: false }
+        };
+        const second = {
+            uuid: 'second',
+            config: { uuid: 'second', isDisabled: false }
+        };
+
+        manager._enqueueRefreshImmediate('claude-kiro-oauth', first, true);
+        manager._enqueueRefreshImmediate('claude-kiro-oauth', second, true);
+
+        await new Promise(resolve => setImmediate(resolve));
+        await new Promise(resolve => setImmediate(resolve));
+
+        expect(manager._refreshNodeToken).toHaveBeenCalledTimes(2);
+        expect(manager.activeProviderRefreshes).toBe(0);
+        expect(manager.refreshingUuids.size).toBe(0);
+        expect(manager.refreshQueues['claude-kiro-oauth']).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Summary

- refresh expired Kiro access tokens synchronously before unary or streaming generation
- keep valid near-expiry tokens on the existing non-blocking background refresh path
- coalesce concurrent forced refreshes for the same credential
- release provider-level refresh slots after queued credentials finish
- treat malformed expiry timestamps as expired

## Why

When a Kiro access token was already expired, both request paths marked the credential as
`needsRefresh` but immediately sent the stale token upstream. Kiro then returned:

```text
403: The bearer token included in the request is invalid.
```

With multiple credentials expiring near the same time, failover selected another expired
credential. The refresh queue also attached global-slot ownership to the first task instead
of the provider queue, so a queued second credential could finish without releasing the
slot. After enough leaked slots, later refreshes never started and all nodes could remain
in “Refreshing” until the service was restarted.

## Tests

```text
npx jest tests/kiro-token-refresh.test.js --runInBand

PASS tests/kiro-token-refresh.test.js
Tests: 7 passed, 7 total
```

The tests cover unary ordering, streaming ordering, the near-expiry background path,
concurrent refresh coalescing, provider refresh-slot release, and malformed expiry values.

Fixes #680